### PR TITLE
Add multimodal dataset generation pipeline

### DIFF
--- a/pipeline/multimodal/__init__.py
+++ b/pipeline/multimodal/__init__.py
@@ -1,0 +1,1 @@
+"""Multimodal DataEvolver dry-run framework."""

--- a/pipeline/multimodal/edit_review.py
+++ b/pipeline/multimodal/edit_review.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+VALID_EDIT_STATUS = {"pass", "fail", "uncertain"}
+
+
+def _constraint(constraint_id: str, kind: str, description: str) -> dict:
+    return {
+        "constraint_id": constraint_id,
+        "type": kind,
+        "description": description,
+    }
+
+
+def default_edit_constraints(edit_instruction: str) -> list[dict]:
+    return [
+        _constraint(
+            "c_instruction_following",
+            "instruction_following",
+            f"The edited image visibly follows the requested edit: {edit_instruction}",
+        ),
+        _constraint(
+            "c_source_preservation",
+            "source_preservation",
+            "Unmentioned source-image objects, scene layout, camera view, and overall identity remain recognizable.",
+        ),
+        _constraint(
+            "c_edit_locality",
+            "edit_locality",
+            "The visual change is localized to the requested target or region instead of rewriting the whole image.",
+        ),
+        _constraint(
+            "c_identity_consistency",
+            "identity_consistency",
+            "The edited target remains the same object category/shape unless the instruction explicitly asks otherwise.",
+        ),
+        _constraint(
+            "c_background_preservation",
+            "background_preservation",
+            "The background, lighting, and non-target composition are preserved unless explicitly requested.",
+        ),
+        _constraint(
+            "c_artifact_quality",
+            "artifact_quality",
+            "The edited result is coherent, not blank, not overpainted, and has no obvious artifacts, text, logos, or watermarks.",
+        ),
+    ]
+
+
+def normalize_edit_constraints(constraints: Optional[Iterable[dict]], edit_instruction: str) -> list[dict]:
+    normalized = []
+    seen = set()
+    for idx, item in enumerate(constraints or []):
+        if not isinstance(item, dict):
+            continue
+        cid = str(item.get("constraint_id") or item.get("id") or f"c_edit_{idx + 1:02d}").strip()
+        desc = str(item.get("description") or item.get("constraint") or "").strip()
+        if not cid or not desc or cid in seen:
+            continue
+        seen.add(cid)
+        normalized.append(
+            _constraint(
+                cid,
+                str(item.get("type") or item.get("kind") or "instruction_following").strip(),
+                desc,
+            )
+        )
+    return normalized if normalized else default_edit_constraints(edit_instruction)
+
+
+def normalize_edit_review(review: Optional[dict], constraints: list[dict]) -> dict:
+    review = review if isinstance(review, dict) else {}
+    by_id = {item["constraint_id"]: item for item in constraints}
+    checklist = review.get("edit_checklist")
+    if not isinstance(checklist, list):
+        checklist = review.get("constraint_checklist")
+    if not isinstance(checklist, list):
+        checklist = []
+
+    rows = []
+    seen = set()
+    for item in checklist:
+        if not isinstance(item, dict):
+            continue
+        cid = str(item.get("constraint_id") or item.get("id") or "").strip()
+        if not cid:
+            continue
+        base = by_id.get(cid, _constraint(cid, str(item.get("type") or "instruction_following"), str(item.get("description") or "")))
+        status = str(item.get("status") or "").strip().lower()
+        if status not in VALID_EDIT_STATUS:
+            status = "uncertain"
+        confidence = str(item.get("confidence") or "medium").strip().lower()
+        if confidence not in {"low", "medium", "high"}:
+            confidence = "medium"
+        rows.append(
+            {
+                "constraint_id": cid,
+                "type": str(item.get("type") or base["type"]),
+                "description": str(item.get("description") or base["description"]),
+                "status": status,
+                "evidence": str(item.get("evidence") or "").strip(),
+                "confidence": confidence,
+            }
+        )
+        seen.add(cid)
+
+    for constraint in constraints:
+        if constraint["constraint_id"] not in seen:
+            rows.append(
+                {
+                    **constraint,
+                    "status": "uncertain",
+                    "evidence": "Constraint was not explicitly judged by the reviewer.",
+                    "confidence": "low",
+                }
+            )
+
+    passed = [row for row in rows if row["status"] == "pass"]
+    failed = [row for row in rows if row["status"] == "fail"]
+    uncertain = [row for row in rows if row["status"] == "uncertain"]
+    route = str(review.get("vlm_route") or "").strip().lower()
+    if route not in {"pass", "needs_fix", "reject"}:
+        route = "pass" if not failed and not uncertain else "needs_fix"
+    if (failed or uncertain) and route == "pass":
+        route = "needs_fix"
+    if any(row["constraint_id"] == "c_artifact_quality" and row["status"] == "fail" for row in failed):
+        route = "reject" if len(failed) >= 3 else route
+
+    pass_rate = round(len(passed) / max(1, len(rows)), 4)
+    return {
+        **review,
+        "schema_version": "edit_constraint_review_v1",
+        "vlm_route": route,
+        "edit_checklist": rows,
+        "constraint_checklist": rows,
+        "passed_edit_constraints": [row["constraint_id"] for row in passed],
+        "failed_edit_constraints": [row["constraint_id"] for row in failed],
+        "uncertain_edit_constraints": [row["constraint_id"] for row in uncertain],
+        "edit_status_counts": {
+            "pass": len(passed),
+            "fail": len(failed),
+            "uncertain": len(uncertain),
+            "total": len(rows),
+        },
+        "edit_pass_rate": pass_rate,
+        "issue_tags": _issue_tags(failed, uncertain),
+        "scores": _scores(pass_rate, failed, uncertain),
+    }
+
+
+def _issue_tags(failed: list[dict], uncertain: list[dict]) -> list[str]:
+    if not failed and not uncertain:
+        return ["none"]
+    kinds = {str(row.get("type")) for row in failed + uncertain}
+    tags = []
+    if "instruction_following" in kinds:
+        tags.append("instruction_not_followed")
+    if "source_preservation" in kinds or "background_preservation" in kinds:
+        tags.append("source_not_preserved")
+    if "edit_locality" in kinds:
+        tags.append("edit_not_local")
+    if "artifact_quality" in kinds:
+        tags.append("edit_artifact")
+    if "identity_consistency" in kinds:
+        tags.append("identity_drift")
+    return tags[:4] or ["edit_constraint_miss"]
+
+
+def _scores(pass_rate: float, failed: list[dict], uncertain: list[dict]) -> dict:
+    overall = max(1, min(5, round(pass_rate * 5)))
+    if failed:
+        overall = min(overall, 3)
+    elif uncertain:
+        overall = min(overall, 4)
+    by_type = {row["type"]: row["status"] for row in failed + uncertain}
+    return {
+        "instruction_following": 2 if by_type.get("instruction_following") == "fail" else overall,
+        "source_preservation": 2 if by_type.get("source_preservation") == "fail" else overall,
+        "edit_locality": 2 if by_type.get("edit_locality") == "fail" else overall,
+        "identity_consistency": 2 if by_type.get("identity_consistency") == "fail" else overall,
+        "artifact_quality": 2 if by_type.get("artifact_quality") == "fail" else overall,
+        "overall": overall,
+    }
+
+
+def _build_edit_review_prompt(
+    *,
+    sample_id: str,
+    edit_instruction: str,
+    constraints: list[dict],
+) -> tuple[str, str]:
+    schema = {
+        "schema_version": "edit_constraint_review_v1",
+        "sample_id": sample_id,
+        "vlm_route": "<pass|needs_fix|reject>",
+        "edit_checklist": [
+            {
+                "constraint_id": "<id from provided checklist>",
+                "type": "<constraint type>",
+                "description": "<constraint being checked>",
+                "status": "<pass|fail|uncertain>",
+                "evidence": "<brief visual evidence, 20 words or fewer>",
+                "confidence": "<low|medium|high>",
+            }
+        ],
+        "failed_edit_constraints": ["<constraint_id>"],
+        "uncertain_edit_constraints": ["<constraint_id>"],
+        "passed_edit_constraints": ["<constraint_id>"],
+        "rewrite_suggestions": ["<specific edit-instruction rewrite suggestion>"],
+        "summary": "<one sentence>",
+    }
+    system_msg = (
+        "You are a strict image-editing dataset reviewer. "
+        "You compare a SOURCE image and an EDITED image against a natural-language edit instruction. "
+        "Return ONLY valid JSON, no markdown fences or extra text. "
+        "Do not include chain-of-thought, self-correction, or long reasoning. Keep evidence concise."
+    )
+    user_msg = (
+        "Image 1 is the SOURCE image before editing. Image 2 is the EDITED result.\n\n"
+        f"sample_id={sample_id}\n"
+        f"Edit instruction:\n{edit_instruction}\n\n"
+        "Provided edit checklist. Judge every item independently:\n"
+        f"{json.dumps(constraints, indent=2, ensure_ascii=False)}\n\n"
+        "Review procedure:\n"
+        "1. Compare Image 2 (edited) against Image 1 (source).\n"
+        "2. Mark instruction_following pass only if the requested edit is visibly completed.\n"
+        "3. Mark source_preservation/background_preservation pass only if unmentioned objects and layout remain recognizable.\n"
+        "4. Mark edit_locality fail if the whole image is repainted, the background changes unnecessarily, or non-target objects change substantially.\n"
+        "5. Mark artifact_quality fail for blank outputs, solid-color images, severe blur, malformed objects, text/logos/watermarks, or obvious model artifacts.\n"
+        "6. Set vlm_route=pass only when all checklist items pass; otherwise use needs_fix or reject.\n\n"
+        "JSON schema to return:\n"
+        f"{json.dumps(schema, indent=2, ensure_ascii=False)}"
+    )
+    return system_msg, user_msg
+
+
+def run_edit_constraint_review(
+    *,
+    edited_path: str,
+    source_path: str,
+    sample_id: str,
+    edit_instruction: str,
+    constraints: Optional[Iterable[dict]] = None,
+    device: str = "cuda:0",
+    max_retries: int = 2,
+    vlm_model_path: Optional[str] = None,
+    enable_thinking: bool = False,
+) -> dict:
+    normalized_constraints = normalize_edit_constraints(constraints, edit_instruction)
+    if vlm_model_path:
+        os.environ["VLM_MODEL_PATH"] = vlm_model_path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pipeline_dir = repo_root / "pipeline"
+    import sys
+
+    if str(pipeline_dir) not in sys.path:
+        sys.path.insert(0, str(pipeline_dir))
+
+    try:
+        import torch
+        from qwen_vl_utils import process_vision_info
+        from pipeline.stage5_5_vlm_review import _extract_json, load_vlm
+    except Exception as exc:
+        fallback = normalize_edit_review({}, normalized_constraints)
+        fallback.update(
+            {
+                "sample_id": sample_id,
+                "edit_instruction": edit_instruction,
+                "source_path": source_path,
+                "edited_path": edited_path,
+                "review_backend": "edit_constraint_import_fallback",
+                "parse_mode": "import_failed",
+                "error": str(exc),
+            }
+        )
+        return fallback
+
+    model, processor = load_vlm(device)
+    system_msg, user_msg = _build_edit_review_prompt(
+        sample_id=sample_id,
+        edit_instruction=edit_instruction,
+        constraints=normalized_constraints,
+    )
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": system_msg}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": source_path},
+                {"type": "image", "image": edited_path},
+                {"type": "text", "text": user_msg},
+            ],
+        },
+    ]
+    dialogue = {
+        "sample_id": sample_id,
+        "system_prompt": system_msg,
+        "user_prompt": user_msg,
+        "attempts": [],
+    }
+    for attempt in range(max(1, max_retries)):
+        try:
+            text_input = processor.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                chat_template_kwargs={"enable_thinking": bool(enable_thinking)},
+            )
+            text_input = text_input + "{"
+            image_inputs, video_inputs = process_vision_info(messages)
+            inputs = processor(
+                text=[text_input],
+                images=image_inputs,
+                videos=video_inputs,
+                padding=True,
+                return_tensors="pt",
+            ).to(device)
+            with torch.no_grad():
+                output_ids = model.generate(
+                    **inputs,
+                    max_new_tokens=3072,
+                    do_sample=False,
+                    temperature=None,
+                    top_p=None,
+                )
+            generated = output_ids[0][inputs.input_ids.shape[1] :]
+            text_out = "{" + processor.decode(generated, skip_special_tokens=True)
+            parsed = _extract_json(text_out)
+            dialogue["attempts"].append(
+                {
+                    "attempt": attempt + 1,
+                    "assistant_text": text_out,
+                    "parse_mode": "direct_json" if parsed is not None else "failed",
+                }
+            )
+            if parsed is not None:
+                review = normalize_edit_review(parsed, normalized_constraints)
+                review.update(
+                    {
+                        "sample_id": sample_id,
+                        "edit_instruction": edit_instruction,
+                        "source_path": source_path,
+                        "edited_path": edited_path,
+                        "review_backend": "qwen_edit_constraint_json",
+                        "parse_mode": "direct_json",
+                        "used_thinking": bool(enable_thinking),
+                        "vlm_dialogue": dialogue,
+                    }
+                )
+                return review
+        except Exception as exc:
+            dialogue["attempts"].append(
+                {
+                    "attempt": attempt + 1,
+                    "parse_mode": "exception",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+
+    fallback = normalize_edit_review({}, normalized_constraints)
+    fallback.update(
+        {
+            "sample_id": sample_id,
+            "edit_instruction": edit_instruction,
+            "source_path": source_path,
+            "edited_path": edited_path,
+            "review_backend": "edit_constraint_neutral_fallback",
+            "parse_mode": "neutral_fallback",
+            "used_thinking": bool(enable_thinking),
+            "vlm_dialogue": dialogue,
+        }
+    )
+    return fallback

--- a/pipeline/multimodal/generators/__init__.py
+++ b/pipeline/multimodal/generators/__init__.py
@@ -1,0 +1,1 @@
+"""Generator adapters for multimodal DataEvolver."""

--- a/pipeline/multimodal/generators/base.py
+++ b/pipeline/multimodal/generators/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List
+
+from ..schemas import DatasetRequest, DatasetSample
+
+
+class GeneratorAdapter(ABC):
+    name = "base"
+
+    @abstractmethod
+    def generate(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        raise NotImplementedError

--- a/pipeline/multimodal/generators/dryrun.py
+++ b/pipeline/multimodal/generators/dryrun.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import struct
+import zlib
+from pathlib import Path
+from typing import Iterable, List
+
+from ..prompt_writer import build_prompts
+from ..schemas import DatasetRequest, DatasetSample, relpath
+from .base import GeneratorAdapter
+
+
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+
+
+def _png_chunk(kind: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + kind + data + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+
+
+def write_placeholder_png(path: Path, *, seed_text: str, width: int = 320, height: int = 240) -> None:
+    digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
+    c1 = tuple(digest[:3])
+    c2 = tuple(digest[3:6])
+    c3 = tuple(digest[6:9])
+    rows = []
+    for y in range(height):
+        row = bytearray([0])
+        for x in range(width):
+            if x < width // 3:
+                color = c1
+            elif x < 2 * width // 3:
+                color = c2
+            else:
+                color = c3
+            shade = 24 if ((x // 16) + (y // 16)) % 2 else 0
+            row.extend(max(0, min(255, channel + shade)) for channel in color)
+        rows.append(bytes(row))
+
+    raw = b"".join(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = [
+        b"\x89PNG\r\n\x1a\n",
+        _png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)),
+        _png_chunk(b"tEXt", b"Software\x00DataEvolver multimodal dry-run"),
+        _png_chunk(b"IDAT", zlib.compress(raw, 9)),
+        _png_chunk(b"IEND", b""),
+    ]
+    path.write_bytes(b"".join(payload))
+
+
+def write_placeholder_gif(path: Path, *, seed_text: str, width: int = 320, height: int = 240, frames: int = 8) -> None:
+    from PIL import Image, ImageDraw
+
+    digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
+    palette = [tuple(digest[i : i + 3]) for i in range(0, 18, 3)]
+    images = []
+    width = max(64, int(width))
+    height = max(64, int(height))
+    frame_count = max(2, int(frames))
+    for idx in range(frame_count):
+        bg = palette[idx % len(palette)]
+        fg = palette[(idx + 2) % len(palette)]
+        img = Image.new("RGB", (width, height), bg)
+        draw = ImageDraw.Draw(img)
+        margin = max(8, min(width, height) // 12)
+        span = max(16, width - 2 * margin)
+        cx = margin + int((span * idx) / max(1, frame_count - 1))
+        cy = height // 2 + int(((idx % 3) - 1) * height * 0.08)
+        radius = max(10, min(width, height) // 9)
+        draw.ellipse((cx - radius, cy - radius, cx + radius, cy + radius), fill=fg)
+        draw.rectangle((margin, height - margin * 2, width - margin, height - margin), outline=fg, width=3)
+        images.append(img)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    images[0].save(path, save_all=True, append_images=images[1:], duration=125, loop=0)
+
+
+def iter_images(input_dir: Path) -> Iterable[Path]:
+    for path in sorted(input_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTS:
+            yield path
+
+
+class DryRunGenerator(GeneratorAdapter):
+    name = "dryrun"
+
+    def generate(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        if request.route == "t2i":
+            return self._generate_t2i(request, output_root)
+        if request.route == "edit":
+            return self._generate_edit(request, output_root)
+        if request.route == "blender":
+            return self._generate_blender_stub(request, output_root)
+        if request.route == "t2v":
+            return self._generate_t2v_stub(request, output_root)
+        raise ValueError(f"Unsupported route for dry-run: {request.route}")
+
+    def _base_review(self) -> dict:
+        return {
+            "status": "pending",
+            "enabled": False,
+            "reason": "VLM evaluation is reserved for a later phase",
+        }
+
+    def _generate_t2i(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        samples = []
+        for prompt_row in build_prompts(request, request.num_samples):
+            sample_id = prompt_row["sample_id"]
+            out_path = output_root / "samples" / "images" / f"{sample_id}.png"
+            existed = out_path.exists()
+            if not (request.skip_existing and existed):
+                write_placeholder_png(
+                    out_path,
+                    seed_text=f"{request.seed}:{sample_id}:{prompt_row['prompt']}",
+                    width=request.width,
+                    height=request.height,
+                )
+            samples.append(
+                DatasetSample(
+                    sample_id=sample_id,
+                    route=request.route,
+                    prompt=prompt_row["prompt"],
+                    output_path=relpath(out_path, output_root),
+                    generator=self.name,
+                    status="skipped_existing" if existed and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": True,
+                        "backend": "placeholder_png",
+                        "intended_model": request.model_name,
+                        "intended_model_path": request.model_path,
+                        "original_prompt": prompt_row.get("original_prompt", prompt_row["prompt"]),
+                        "rewritten_prompt": prompt_row.get("rewritten_prompt", prompt_row["prompt"]),
+                        "constraints": prompt_row.get("constraints", []),
+                        "tier": prompt_row.get("tier"),
+                        "source_prompt_id": prompt_row.get("source_prompt_id"),
+                        "rewrite_reason": prompt_row.get("rewrite_reason"),
+                    },
+                    vlm_review=self._base_review(),
+                )
+            )
+        return samples
+
+    def _generate_edit(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        input_dir = Path(request.input_image_dir or "")
+        if not input_dir.exists() or not input_dir.is_dir():
+            raise FileNotFoundError(f"input image directory not found: {input_dir}")
+
+        image_paths = list(iter_images(input_dir))[: request.num_samples]
+        if not image_paths:
+            raise FileNotFoundError(f"no images found in input image directory: {input_dir}")
+
+        prompt_rows = build_prompts(request, len(image_paths))
+        samples = []
+        for prompt_row, src in zip(prompt_rows, image_paths):
+            sample_id = prompt_row["sample_id"]
+            out_path = output_root / "samples" / "edited" / f"{sample_id}{src.suffix.lower()}"
+            existed = out_path.exists()
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            if not (request.skip_existing and existed):
+                shutil.copy2(src, out_path)
+            samples.append(
+                DatasetSample(
+                    sample_id=sample_id,
+                    route=request.route,
+                    prompt=prompt_row["prompt"],
+                    input_path=str(src),
+                    output_path=relpath(out_path, output_root),
+                    edit_instruction=prompt_row["edit_instruction"],
+                    generator=self.name,
+                    status="skipped_existing" if existed and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": True,
+                        "backend": "copy_input_image",
+                        "intended_model": request.model_name,
+                        "intended_model_path": request.model_path,
+                        "source_filename": src.name,
+                        "original_edit_instruction": prompt_row.get(
+                            "original_edit_instruction",
+                            prompt_row["edit_instruction"],
+                        ),
+                        "model_edit_instruction": prompt_row["edit_instruction"],
+                        "constraints": prompt_row.get("constraints", []),
+                        "tier": prompt_row.get("tier"),
+                        "source_prompt_id": prompt_row.get("source_prompt_id"),
+                        "rewrite_reason": prompt_row.get("rewrite_reason"),
+                    },
+                    vlm_review=self._base_review(),
+                )
+            )
+        return samples
+
+    def _generate_blender_stub(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        prompt_row = build_prompts(request, 1)[0]
+        marker = output_root / "samples" / "blender" / f"{prompt_row['sample_id']}.json"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(
+            "{\n"
+            '  "status": "dryrun_stub",\n'
+            '  "intended_route": "existing Blender pipeline",\n'
+            '  "real_entrypoints": ["pipeline/run_all.sh", "scripts/run_full_pipeline.py"]\n'
+            "}\n",
+            encoding="utf-8",
+        )
+        return [
+            DatasetSample(
+                sample_id=prompt_row["sample_id"],
+                route=request.route,
+                prompt=prompt_row["prompt"],
+                output_path=relpath(marker, output_root),
+                generator=self.name,
+                status="stub",
+                metadata={
+                    "dry_run": True,
+                    "backend": "blender_route_marker",
+                    "intended_model": request.model_name,
+                    "intended_model_path": request.model_path,
+                },
+                vlm_review=self._base_review(),
+            )
+        ]
+
+    def _generate_t2v_stub(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        samples = []
+        for prompt_row in build_prompts(request, request.num_samples):
+            sample_id = prompt_row["sample_id"]
+            out_path = output_root / "samples" / "videos" / f"{sample_id}.gif"
+            existed = out_path.exists()
+            if not (request.skip_existing and existed):
+                write_placeholder_gif(
+                    out_path,
+                    seed_text=f"{request.seed}:{sample_id}:{prompt_row['prompt']}",
+                    width=request.width,
+                    height=request.height,
+                    frames=min(max(request.num_frames, 2), 16),
+                )
+            samples.append(
+                DatasetSample(
+                    sample_id=sample_id,
+                    route=request.route,
+                    prompt=prompt_row["prompt"],
+                    output_path=relpath(out_path, output_root),
+                    generator=self.name,
+                    status="skipped_existing" if existed and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": True,
+                        "backend": "placeholder_gif_video",
+                        "intended_model": request.model_name,
+                        "intended_model_path": request.model_path,
+                        "original_prompt": prompt_row.get("original_prompt", prompt_row["prompt"]),
+                        "rewritten_prompt": prompt_row.get("rewritten_prompt", prompt_row["prompt"]),
+                        "negative_prompt": prompt_row.get("negative_prompt", request.negative_prompt),
+                        "constraints": prompt_row.get("constraints", []),
+                        "num_frames": request.num_frames,
+                        "fps": request.fps,
+                        "tier": prompt_row.get("tier"),
+                        "source_prompt_id": prompt_row.get("source_prompt_id"),
+                        "rewrite_reason": prompt_row.get("rewrite_reason"),
+                    },
+                    vlm_review=self._base_review(),
+                )
+            )
+        return samples

--- a/pipeline/multimodal/generators/qwen_image.py
+++ b/pipeline/multimodal/generators/qwen_image.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from ..prompt_writer import build_prompts
+from ..schemas import DatasetRequest, DatasetSample, relpath
+from .base import GeneratorAdapter
+
+
+class QwenImageGenerator(GeneratorAdapter):
+    name = "qwen-image"
+
+    def generate(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        if not request.allow_model_inference or request.dry_run:
+            raise RuntimeError("Qwen image inference requires --allow-model-inference and non-dry-run mode")
+        if request.route != "t2i":
+            raise ValueError("QwenImageGenerator only supports route=t2i")
+
+        prompt_rows = build_prompts(request, request.num_samples)
+        prompt_path = output_root / "model_inputs" / "t2i_prompts.json"
+        image_dir = output_root / "samples" / "images"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        image_dir.mkdir(parents=True, exist_ok=True)
+        prompt_payload = [
+            {
+                "id": row["sample_id"],
+                "name": row["sample_id"],
+                "prompt": row["prompt"],
+                "features": {},
+            }
+            for row in prompt_rows
+        ]
+        prompt_path.write_text(json.dumps(prompt_payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        repo_root = Path(__file__).resolve().parents[3]
+        stage2 = repo_root / "pipeline" / "stage2_t2i_generate.py"
+        existed_before = {
+            row["sample_id"]: (image_dir / f"{row['sample_id']}.png").exists()
+            for row in prompt_rows
+        }
+        log_dir = output_root / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        if not (request.skip_existing and all(existed_before.values())):
+            cmd = [
+                sys.executable,
+                str(stage2),
+                "--prompts-path",
+                str(prompt_path),
+                "--output-dir",
+                str(image_dir),
+                "--device",
+                request.device,
+                "--height",
+                str(request.height),
+                "--width",
+                str(request.width),
+                "--steps",
+                str(request.steps),
+                "--cfg-scale",
+                str(request.true_cfg_scale),
+                "--seed-base",
+                str(request.seed),
+            ]
+            if not request.skip_existing:
+                cmd.append("--no-skip")
+            env = None
+            if request.model_path:
+                import os
+
+                env = dict(os.environ)
+                env["QWEN_IMAGE_MODEL_PATH"] = request.model_path
+            result = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True, env=env, timeout=3600)
+            (log_dir / "qwen_image_stage2.stdout.log").write_text(result.stdout or "", encoding="utf-8")
+            (log_dir / "qwen_image_stage2.stderr.log").write_text(result.stderr or "", encoding="utf-8")
+            if result.returncode != 0:
+                raise RuntimeError(f"stage2_t2i_generate.py failed with code {result.returncode}; see {log_dir}")
+        else:
+            (log_dir / "qwen_image_stage2.stdout.log").write_text("[multimodal] skipped existing outputs\n", encoding="utf-8")
+            (log_dir / "qwen_image_stage2.stderr.log").write_text("", encoding="utf-8")
+
+        samples: List[DatasetSample] = []
+        for row in prompt_rows:
+            out_path = image_dir / f"{row['sample_id']}.png"
+            if not out_path.exists():
+                raise FileNotFoundError(f"expected T2I output missing: {out_path}")
+            samples.append(
+                DatasetSample(
+                    sample_id=row["sample_id"],
+                    route=request.route,
+                    prompt=row["prompt"],
+                    output_path=relpath(out_path, output_root),
+                    generator=self.name,
+                    status="skipped_existing" if existed_before.get(row["sample_id"]) and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": False,
+                        "backend": "pipeline.stage2_t2i_generate",
+                        "model_name": request.model_name,
+                        "model_path": request.model_path,
+                        "device": request.device,
+                        "height": request.height,
+                        "width": request.width,
+                        "steps": request.steps,
+                        "cfg_scale": request.true_cfg_scale,
+                        "original_prompt": row.get("original_prompt", row["prompt"]),
+                        "rewritten_prompt": row.get("rewritten_prompt", row["prompt"]),
+                        "constraints": row.get("constraints", []),
+                        "tier": row.get("tier"),
+                        "source_prompt_id": row.get("source_prompt_id"),
+                        "rewrite_reason": row.get("rewrite_reason"),
+                        "stage2_stdout_log": relpath(log_dir / "qwen_image_stage2.stdout.log", output_root),
+                        "stage2_stderr_log": relpath(log_dir / "qwen_image_stage2.stderr.log", output_root),
+                    },
+                    vlm_review={
+                        "status": "pending",
+                        "enabled": False,
+                        "reason": "VLM evaluation is deferred",
+                    },
+                )
+            )
+        return samples

--- a/pipeline/multimodal/generators/qwen_image_edit.py
+++ b/pipeline/multimodal/generators/qwen_image_edit.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import List
+
+from ..prompt_writer import build_prompts
+from ..schemas import DatasetRequest, DatasetSample, relpath
+from .base import GeneratorAdapter
+from .dryrun import iter_images
+
+
+class QwenImageEditGenerator(GeneratorAdapter):
+    name = "qwen-image-edit"
+
+    def generate(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        if not request.allow_model_inference or request.dry_run:
+            raise RuntimeError("Qwen image edit inference requires --allow-model-inference and non-dry-run mode")
+        if request.route != "edit":
+            raise ValueError("QwenImageEditGenerator only supports route=edit")
+
+        input_dir = Path(request.input_image_dir or "")
+        image_paths = list(iter_images(input_dir))[: request.num_samples]
+        if not image_paths:
+            raise FileNotFoundError(f"no images found in input image directory: {input_dir}")
+
+        samples: List[DatasetSample] = []
+        prompt_rows = build_prompts(request, len(image_paths))
+        planned = []
+        for idx, (prompt_row, src) in enumerate(zip(prompt_rows, image_paths)):
+            sample_id = prompt_row["sample_id"]
+            out_path = output_root / "samples" / "edited" / f"{sample_id}.png"
+            planned.append((idx, prompt_row, src, out_path, out_path.exists()))
+
+        if request.skip_existing and all(item[4] for item in planned):
+            for idx, prompt_row, src, out_path, existed in planned:
+                samples.append(
+                    DatasetSample(
+                        sample_id=prompt_row["sample_id"],
+                        route=request.route,
+                        prompt=prompt_row["prompt"],
+                        input_path=str(src),
+                        output_path=relpath(out_path, output_root),
+                        edit_instruction=prompt_row["edit_instruction"],
+                        generator=self.name,
+                        status="skipped_existing",
+                        metadata={
+                            "dry_run": False,
+                            "backend": "diffusers.QwenImageEditPlusPipeline",
+                            "model_name": request.model_name,
+                            "model_path": request.model_path or "/data/wuwenzhuo/Qwen-Image-Edit-2511",
+                            "device": request.device,
+                            "height": request.height,
+                            "width": request.width,
+                            "steps": request.steps,
+                            "elapsed_seconds": 0.0,
+                            "resume_skip": True,
+                            "original_edit_instruction": prompt_row.get(
+                                "original_edit_instruction",
+                                prompt_row["edit_instruction"],
+                            ),
+                            "model_edit_instruction": prompt_row["edit_instruction"],
+                            "constraints": prompt_row.get("constraints", []),
+                            "tier": prompt_row.get("tier"),
+                            "source_prompt_id": prompt_row.get("source_prompt_id"),
+                            "rewrite_reason": prompt_row.get("rewrite_reason"),
+                        },
+                        vlm_review={
+                            "status": "pending",
+                            "enabled": False,
+                            "reason": "VLM evaluation is deferred",
+                        },
+                    )
+                )
+            return samples
+
+        import torch
+        from PIL import Image
+        from diffusers import QwenImageEditPlusPipeline
+
+        model_path = request.model_path or "/data/wuwenzhuo/Qwen-Image-Edit-2511"
+        pipe = QwenImageEditPlusPipeline.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+        pipe.to(request.device)
+        pipe.set_progress_bar_config(disable=None)
+
+        for idx, prompt_row, src, out_path, existed in planned:
+            sample_id = prompt_row["sample_id"]
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            start = time.time()
+            if not (request.skip_existing and existed):
+                image = Image.open(src).convert("RGB")
+                generator = torch.Generator(device=request.device).manual_seed(request.seed + idx)
+                with torch.inference_mode():
+                    output = pipe(
+                        image=image,
+                        prompt=prompt_row["edit_instruction"],
+                        generator=generator,
+                        true_cfg_scale=request.true_cfg_scale,
+                        negative_prompt=" ",
+                        num_inference_steps=request.steps,
+                        guidance_scale=request.guidance_scale,
+                        height=request.height,
+                        width=request.width,
+                        num_images_per_prompt=1,
+                    )
+                output.images[0].save(out_path)
+            samples.append(
+                DatasetSample(
+                    sample_id=sample_id,
+                    route=request.route,
+                    prompt=prompt_row["prompt"],
+                    input_path=str(src),
+                    output_path=relpath(out_path, output_root),
+                    edit_instruction=prompt_row["edit_instruction"],
+                    generator=self.name,
+                    status="skipped_existing" if existed and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": False,
+                        "backend": "diffusers.QwenImageEditPlusPipeline",
+                        "model_name": request.model_name,
+                        "model_path": model_path,
+                        "device": request.device,
+                        "height": request.height,
+                        "width": request.width,
+                        "steps": request.steps,
+                        "elapsed_seconds": round(time.time() - start, 3),
+                        "original_edit_instruction": prompt_row.get(
+                            "original_edit_instruction",
+                            prompt_row["edit_instruction"],
+                        ),
+                        "model_edit_instruction": prompt_row["edit_instruction"],
+                        "constraints": prompt_row.get("constraints", []),
+                        "tier": prompt_row.get("tier"),
+                        "source_prompt_id": prompt_row.get("source_prompt_id"),
+                        "rewrite_reason": prompt_row.get("rewrite_reason"),
+                    },
+                    vlm_review={
+                        "status": "pending",
+                        "enabled": False,
+                        "reason": "VLM evaluation is deferred",
+                    },
+                )
+            )
+
+        del pipe
+        if request.device.startswith("cuda") and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        return samples

--- a/pipeline/multimodal/generators/wan_t2v.py
+++ b/pipeline/multimodal/generators/wan_t2v.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List
+
+from ..prompt_writer import build_prompts
+from ..schemas import DatasetRequest, DatasetSample, relpath
+from .base import GeneratorAdapter
+
+
+class WanT2VGenerator(GeneratorAdapter):
+    name = "wan-t2v"
+
+    def generate(self, request: DatasetRequest, output_root: Path) -> List[DatasetSample]:
+        if not request.allow_model_inference or request.dry_run:
+            raise RuntimeError("Wan T2V inference requires --allow-model-inference and non-dry-run mode")
+        if request.route != "t2v":
+            raise ValueError("WanT2VGenerator only supports route=t2v")
+        if not request.model_path:
+            raise ValueError("Wan T2V requires --model-path or WAN_T2V_MODEL_PATH")
+
+        prompt_rows = build_prompts(request, request.num_samples)
+        prompt_path = output_root / "model_inputs" / "t2v_prompts.json"
+        video_dir = output_root / "samples" / "videos"
+        log_dir = output_root / "logs"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        video_dir.mkdir(parents=True, exist_ok=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        prompt_payload = [
+            {
+                "id": row["sample_id"],
+                "prompt": row["prompt"],
+                "negative_prompt": row.get("negative_prompt", request.negative_prompt),
+            }
+            for row in prompt_rows
+        ]
+        prompt_path.write_text(json.dumps(prompt_payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        existed_before = {
+            row["sample_id"]: (video_dir / f"{row['sample_id']}.mp4").exists()
+            for row in prompt_rows
+        }
+        if request.skip_existing and all(existed_before.values()):
+            (log_dir / "wan_t2v.log").write_text("[multimodal] skipped existing outputs\n", encoding="utf-8")
+            return self._samples(request, output_root, prompt_rows, video_dir, log_dir, existed_before)
+
+        import torch
+        from diffusers import WanPipeline
+        from diffusers.utils import export_to_video
+
+        model_path = Path(request.model_path)
+        if not model_path.exists():
+            raise FileNotFoundError(f"Wan model path not found: {model_path}")
+
+        log_lines = [
+            f"model_path={model_path}",
+            f"device={request.device}",
+            f"height={request.height} width={request.width} frames={request.num_frames}",
+            f"steps={request.steps} guidance_scale={request.guidance_scale}",
+        ]
+        pipe = WanPipeline.from_pretrained(
+            str(model_path),
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+        if request.device.startswith("cuda") and os.environ.get("WAN_T2V_CPU_OFFLOAD") == "1":
+            pipe.enable_model_cpu_offload()
+            log_lines.append("offload=model_cpu_offload")
+        else:
+            pipe = pipe.to(request.device)
+            log_lines.append(f"pipeline_to={request.device}")
+
+        for idx, row in enumerate(prompt_rows):
+            sample_id = row["sample_id"]
+            out_path = video_dir / f"{sample_id}.mp4"
+            if request.skip_existing and out_path.exists():
+                log_lines.append(f"skip_existing={out_path}")
+                continue
+            seed = int(request.seed) + idx
+            generator_device = request.device if request.device.startswith("cuda") else "cpu"
+            generator = torch.Generator(device=generator_device).manual_seed(seed)
+            negative_prompt = str(row.get("negative_prompt") or request.negative_prompt or "")
+            result = pipe(
+                prompt=row["prompt"],
+                negative_prompt=negative_prompt or None,
+                height=request.height,
+                width=request.width,
+                num_frames=request.num_frames,
+                num_inference_steps=request.steps,
+                guidance_scale=request.guidance_scale,
+                generator=generator,
+                output_type="pil",
+            )
+            frames = result.frames[0]
+            export_to_video(frames, str(out_path), fps=request.fps)
+            log_lines.append(f"generated={out_path} seed={seed} frames={len(frames)}")
+
+        (log_dir / "wan_t2v.log").write_text("\n".join(log_lines) + "\n", encoding="utf-8")
+        return self._samples(request, output_root, prompt_rows, video_dir, log_dir, existed_before)
+
+    def _samples(
+        self,
+        request: DatasetRequest,
+        output_root: Path,
+        prompt_rows: List[dict],
+        video_dir: Path,
+        log_dir: Path,
+        existed_before: dict,
+    ) -> List[DatasetSample]:
+        samples: List[DatasetSample] = []
+        for row in prompt_rows:
+            out_path = video_dir / f"{row['sample_id']}.mp4"
+            if not out_path.exists():
+                raise FileNotFoundError(f"expected T2V output missing: {out_path}")
+            samples.append(
+                DatasetSample(
+                    sample_id=row["sample_id"],
+                    route=request.route,
+                    prompt=row["prompt"],
+                    output_path=relpath(out_path, output_root),
+                    generator=self.name,
+                    status="skipped_existing" if existed_before.get(row["sample_id"]) and request.skip_existing else "generated",
+                    metadata={
+                        "dry_run": False,
+                        "backend": "diffusers.WanPipeline",
+                        "model_name": request.model_name,
+                        "model_path": request.model_path,
+                        "device": request.device,
+                        "height": request.height,
+                        "width": request.width,
+                        "num_frames": request.num_frames,
+                        "fps": request.fps,
+                        "steps": request.steps,
+                        "guidance_scale": request.guidance_scale,
+                        "negative_prompt": row.get("negative_prompt", request.negative_prompt),
+                        "seed": request.seed,
+                        "original_prompt": row.get("original_prompt", row["prompt"]),
+                        "rewritten_prompt": row.get("rewritten_prompt", row["prompt"]),
+                        "constraints": row.get("constraints", []),
+                        "tier": row.get("tier"),
+                        "source_prompt_id": row.get("source_prompt_id"),
+                        "rewrite_reason": row.get("rewrite_reason"),
+                        "wan_log": relpath(log_dir / "wan_t2v.log", output_root),
+                    },
+                    vlm_review={
+                        "status": "pending",
+                        "enabled": False,
+                        "reason": "VLM evaluation is deferred",
+                    },
+                )
+            )
+        return samples

--- a/pipeline/multimodal/model_registry.py
+++ b/pipeline/multimodal/model_registry.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+
+MODEL_REGISTRY: Dict[str, Dict[str, str]] = {
+    "qwen-image-2512": {
+        "route": "t2i",
+        "env": "QWEN_IMAGE_MODEL_PATH",
+        "default_path": "/data/wuwenzhuo/Qwen-Image-2512",
+    },
+    "qwen-image-edit-2511": {
+        "route": "edit",
+        "env": "QWEN_IMAGE_EDIT_MODEL_PATH",
+        "default_path": "/data/wuwenzhuo/Qwen-Image-Edit-2511",
+    },
+    "dataevolver-blender-existing": {
+        "route": "blender",
+        "env": "DATAEVOLVER_BLENDER_ENTRYPOINT",
+        "default_path": "pipeline/run_all.sh",
+    },
+    "wan2.1-t2v-1.3b": {
+        "route": "t2v",
+        "env": "WAN_T2V_MODEL_PATH",
+        "default_path": "/data/jiazhuangzhuang/Wan2.1-T2V-1.3B-Diffusers",
+    },
+    "t2v-placeholder": {
+        "route": "t2v",
+        "env": "DATAEVOLVER_T2V_MODEL_PATH",
+        "default_path": "/data/jiazhuangzhuang/Wan2.1-T2V-1.3B-Diffusers",
+    },
+}
+
+DEFAULT_MODEL_BY_ROUTE = {
+    "t2i": "qwen-image-2512",
+    "edit": "qwen-image-edit-2511",
+    "blender": "dataevolver-blender-existing",
+    "t2v": "wan2.1-t2v-1.3b",
+}
+
+
+def resolve_model(route: str, model_name: Optional[str], model_path: Optional[str]) -> dict:
+    name = (model_name or DEFAULT_MODEL_BY_ROUTE[route]).strip()
+    spec = dict(MODEL_REGISTRY.get(name, {}))
+    if spec and spec.get("route") != route:
+        raise ValueError(f"model '{name}' is registered for route={spec.get('route')}, not route={route}")
+
+    env_name = spec.get("env")
+    resolved_path = model_path or (os.environ.get(env_name) if env_name else None) or spec.get("default_path") or ""
+    return {
+        "model_name": name,
+        "model_path": resolved_path,
+        "registry_hit": bool(spec),
+        "env": env_name,
+    }

--- a/pipeline/multimodal/prompt_writer.py
+++ b/pipeline/multimodal/prompt_writer.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .schemas import DatasetRequest
+
+
+def _clean_request(text: str) -> str:
+    return " ".join((text or "").strip().split())
+
+
+def _row_text(row: dict, *keys: str) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            return _clean_request(str(value))
+    return ""
+
+
+def _row_metadata(row: dict) -> Dict[str, object]:
+    meta: Dict[str, object] = {}
+    for key in (
+        "original_prompt",
+        "rewritten_prompt",
+        "original_edit_instruction",
+        "tier",
+        "source_prompt_id",
+        "rewrite_reason",
+        "negative_prompt",
+    ):
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            meta[key] = value
+    constraints = row.get("constraints")
+    if isinstance(constraints, list):
+        meta["constraints"] = constraints
+    return meta
+
+
+def _load_prompt_file(path: str) -> List[dict]:
+    src = Path(path)
+    if not src.exists():
+        raise FileNotFoundError(f"prompt file not found: {src}")
+    suffix = src.suffix.lower()
+    if suffix == ".json":
+        payload = json.loads(src.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload = payload.get("samples") or payload.get("prompts") or [payload]
+        if not isinstance(payload, list):
+            raise ValueError("JSON prompt file must contain a list or a dict with samples/prompts")
+        return [row if isinstance(row, dict) else {"prompt": str(row)} for row in payload]
+    if suffix == ".jsonl":
+        rows = []
+        for line in src.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                row = json.loads(line)
+                rows.append(row if isinstance(row, dict) else {"prompt": str(row)})
+        return rows
+    return [{"prompt": line.strip()} for line in src.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _edit_model_instruction(instruction: str) -> str:
+    clean = _clean_request(instruction)
+    preservation = (
+        "Apply only this requested edit. Preserve the source image's camera view, layout, background, lighting, "
+        "non-target objects, object identity, and overall composition. Do not repaint the whole image. "
+        "Avoid text, logos, watermarks, blur, or new unrelated objects."
+    )
+    if any(term in clean.lower() for term in ["preserve", "保持", "保留", "unchanged"]):
+        return clean
+    return f"{clean}. {preservation}"
+
+
+def build_prompts(request: DatasetRequest, count: int) -> List[Dict[str, str]]:
+    base = _clean_request(request.user_request)
+    if not base:
+        base = "Create a high-quality multimodal dataset sample"
+
+    file_rows = _load_prompt_file(request.prompt_file) if request.prompt_file else []
+    prompts: List[Dict[str, str]] = []
+    for idx in range(count):
+        file_row = file_rows[idx] if idx < len(file_rows) else {}
+        sample_id = _row_text(file_row, "sample_id", "id") or f"{request.sample_prefix}_{idx + 1:04d}"
+        if request.route == "t2i":
+            prompt = _row_text(file_row, "prompt", "text", "user_request")
+            if not prompt:
+                prompt = (
+                    f"{base}. Produce one clean, inspectable image for dataset sample {idx + 1}. "
+                    "Use stable composition, clear subject identity, and no text watermark."
+                )
+            meta = _row_metadata(file_row)
+            meta.setdefault("original_prompt", _row_text(file_row, "original_prompt") or prompt)
+            meta.setdefault("rewritten_prompt", prompt)
+            prompts.append({"sample_id": sample_id, "prompt": prompt, **meta})
+        elif request.route == "edit":
+            instruction = _row_text(file_row, "edit_instruction", "instruction", "prompt", "text")
+            if not instruction:
+                instruction = (
+                    f"{base}. Edit only the requested visual attributes for sample {idx + 1}; "
+                    "preserve unrelated content, layout, and image identity."
+                )
+            meta = _row_metadata(file_row)
+            meta.setdefault("original_edit_instruction", instruction)
+            model_instruction = _edit_model_instruction(instruction)
+            prompts.append(
+                {
+                    "sample_id": sample_id,
+                    "prompt": model_instruction,
+                    "edit_instruction": model_instruction,
+                    **meta,
+                }
+            )
+        elif request.route == "blender":
+            prompt = (
+                f"{base}. Route this request to the existing Blender dataset pipeline. "
+                "Keep scene assets, render metadata, and loop trace outputs reproducible."
+            )
+            prompts.append({"sample_id": sample_id, "prompt": prompt})
+        else:
+            prompt = _row_text(file_row, "prompt", "text", "user_request")
+            if not prompt:
+                prompt = (
+                    f"{base}. Generate a short, coherent text-to-video dataset sample. "
+                    "Use physically plausible motion, stable camera behavior, consistent subject identity, "
+                    "natural lighting, and a clear beginning-middle-end action. Avoid text, logos, watermarks, "
+                    "flicker, warped anatomy, impossible object motion, and unrelated scene changes."
+                )
+            meta = _row_metadata(file_row)
+            meta.setdefault("original_prompt", _row_text(file_row, "original_prompt") or prompt)
+            meta.setdefault("rewritten_prompt", prompt)
+            if "negative_prompt" not in meta:
+                meta["negative_prompt"] = (
+                    request.negative_prompt
+                    or "text, subtitles, logos, watermark, flicker, jitter, distorted anatomy, "
+                    "warped geometry, impossible physics, abrupt scene cuts, low quality"
+                )
+            prompts.append({"sample_id": sample_id, "prompt": prompt, **meta})
+    return prompts

--- a/pipeline/multimodal/router.py
+++ b/pipeline/multimodal/router.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from .schemas import DatasetRequest, normalize_route
+from .model_registry import resolve_model
+
+
+ROUTE_DESCRIPTIONS = {
+    "t2i": "text prompt to image dataset",
+    "edit": "input image plus edit instruction to edited image dataset",
+    "blender": "existing Blender / 3D dataset route",
+    "t2v": "text prompt to video dataset",
+}
+
+
+def build_request(
+    *,
+    route: str,
+    user_request: str,
+    output_root: str,
+    dry_run: bool,
+    allow_model_inference: bool,
+    num_samples: int,
+    input_image_dir: str | None,
+    prompt_file: str | None,
+    generator: str,
+    model_name: str | None,
+    model_path: str | None,
+    device: str,
+    height: int,
+    width: int,
+    steps: int,
+    num_frames: int,
+    fps: int,
+    true_cfg_scale: float,
+    guidance_scale: float,
+    negative_prompt: str,
+    seed: int,
+    sample_prefix: str,
+    skip_existing: bool,
+    validate_outputs: bool,
+    vlm_eval: bool,
+    vlm_device: str,
+    vlm_model_path: str | None,
+    vlm_max_samples: int | None,
+    vlm_max_retries: int,
+    vlm_review_mode: str,
+    vlm_use_freeform_first: bool,
+    vlm_enable_thinking: bool,
+) -> DatasetRequest:
+    normalized = normalize_route(route)
+    model = resolve_model(normalized, model_name, model_path)
+    notes = [f"route={normalized}: {ROUTE_DESCRIPTIONS[normalized]}"]
+    notes.append(f"model={model['model_name']} path={model['model_path'] or '<unset>'}")
+    if normalized == "edit" and not input_image_dir:
+        raise ValueError("--input-image-dir is required for route=edit")
+    if prompt_file:
+        notes.append(f"prompt_file={prompt_file}")
+    if normalized == "t2v":
+        notes.append("t2v uses a text-to-video generator plus keyframe VLM review loop")
+    if not dry_run and not allow_model_inference:
+        notes.append("real model inference requested but blocked until --allow-model-inference is set")
+    elif not dry_run:
+        notes.append("real model inference is enabled through the selected adapter")
+    return DatasetRequest(
+        route=normalized,
+        user_request=user_request.strip(),
+        output_root=output_root,
+        dry_run=dry_run,
+        allow_model_inference=allow_model_inference,
+        num_samples=max(1, int(num_samples)),
+        input_image_dir=input_image_dir,
+        prompt_file=prompt_file,
+        generator=generator,
+        model_name=model["model_name"],
+        model_path=model["model_path"],
+        device=device,
+        height=int(height),
+        width=int(width),
+        num_frames=int(num_frames),
+        fps=int(fps),
+        steps=int(steps),
+        true_cfg_scale=float(true_cfg_scale),
+        guidance_scale=float(guidance_scale),
+        negative_prompt=(negative_prompt or "").strip(),
+        seed=int(seed),
+        sample_prefix=sample_prefix,
+        skip_existing=bool(skip_existing),
+        validate_outputs=bool(validate_outputs),
+        vlm_eval=bool(vlm_eval),
+        vlm_device=vlm_device,
+        vlm_model_path=vlm_model_path,
+        vlm_max_samples=vlm_max_samples,
+        vlm_max_retries=max(1, int(vlm_max_retries)),
+        vlm_review_mode=vlm_review_mode,
+        vlm_use_freeform_first=bool(vlm_use_freeform_first),
+        vlm_enable_thinking=bool(vlm_enable_thinking),
+        notes=notes,
+    )

--- a/pipeline/multimodal/run_multimodal_dataset.py
+++ b/pipeline/multimodal/run_multimodal_dataset.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from pipeline.multimodal.generators.dryrun import DryRunGenerator
+from pipeline.multimodal.router import ROUTE_DESCRIPTIONS, build_request
+from pipeline.multimodal.schemas import DatasetRequest, DatasetSample
+from pipeline.multimodal.validation import validate_image, validate_video
+from pipeline.multimodal.vlm_review import run_vlm_reviews
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a multimodal DataEvolver dataset route")
+    parser.add_argument("--route", required=True, choices=sorted(ROUTE_DESCRIPTIONS))
+    parser.add_argument("--user-request", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--dry-run", action="store_true", help="Use local mock generation; no model inference")
+    parser.add_argument("--allow-model-inference", action="store_true", help="Required for any real model adapter")
+    parser.add_argument("--num-samples", type=int, default=4)
+    parser.add_argument("--input-image-dir", default=None)
+    parser.add_argument("--prompt-file", default=None, help="Optional .txt/.json/.jsonl prompt or instruction list")
+    parser.add_argument("--generator", default="dryrun", help="Generator adapter name. Only dryrun is local-safe now")
+    parser.add_argument("--model-name", default=None, help="Registered or custom model name to record in metadata")
+    parser.add_argument("--model-path", default=None, help="Cloud/local model path to record for later real adapters")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--height", type=int, default=512)
+    parser.add_argument("--width", type=int, default=512)
+    parser.add_argument("--num-frames", type=int, default=49)
+    parser.add_argument("--fps", type=int, default=16)
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--true-cfg-scale", type=float, default=4.0)
+    parser.add_argument("--guidance-scale", type=float, default=1.0)
+    parser.add_argument("--negative-prompt", default="")
+    parser.add_argument("--seed", type=int, default=11)
+    parser.add_argument("--sample-prefix", default="sample")
+    parser.add_argument("--skip-existing", dest="skip_existing", action="store_true", default=True)
+    parser.add_argument("--no-skip-existing", dest="skip_existing", action="store_false")
+    parser.add_argument("--validate-outputs", dest="validate_outputs", action="store_true", default=True)
+    parser.add_argument("--no-validate-outputs", dest="validate_outputs", action="store_false")
+    parser.add_argument("--vlm-eval", action="store_true", help="Run the existing DataEvolver VLM review on generated images")
+    parser.add_argument("--vlm-device", default="cuda:0")
+    parser.add_argument("--vlm-model-path", default=None)
+    parser.add_argument("--vlm-max-samples", type=int, default=None)
+    parser.add_argument("--vlm-max-retries", type=int, default=1)
+    parser.add_argument("--vlm-review-mode", default="studio")
+    parser.add_argument("--vlm-use-freeform-first", action="store_true")
+    parser.add_argument("--vlm-enable-thinking", action="store_true")
+    return parser.parse_args()
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: List[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def select_generator(request: DatasetRequest):
+    if request.dry_run and request.generator == "dryrun":
+        return DryRunGenerator()
+    if not request.allow_model_inference:
+        raise SystemExit("Real model adapters require --allow-model-inference.")
+    if request.generator == "qwen-image-edit" and request.route == "edit":
+        from pipeline.multimodal.generators.qwen_image_edit import QwenImageEditGenerator
+
+        return QwenImageEditGenerator()
+    if request.generator == "qwen-image" and request.route == "t2i":
+        from pipeline.multimodal.generators.qwen_image import QwenImageGenerator
+
+        return QwenImageGenerator()
+    if request.generator in {"wan-t2v", "wan2.1-t2v-1.3b"} and request.route == "t2v":
+        from pipeline.multimodal.generators.wan_t2v import WanT2VGenerator
+
+        return WanT2VGenerator()
+    raise SystemExit(f"Unsupported generator={request.generator!r} for route={request.route!r}")
+
+
+def run(request: DatasetRequest) -> List[DatasetSample]:
+    output_root = Path(request.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+    write_json(output_root / "request.json", request.to_dict())
+
+    generator = select_generator(request)
+    samples = generator.generate(request, output_root)
+    if request.validate_outputs:
+        for sample in samples:
+            output_path = output_root / sample.output_path if sample.output_path else None
+            if request.route == "t2v":
+                sample.validation = validate_video(
+                    output_path,
+                    expected_width=request.width,
+                    expected_height=request.height,
+                    expected_num_frames=request.num_frames,
+                )
+            else:
+                sample.validation = validate_image(
+                    output_path,
+                    expected_width=request.width if request.route in {"t2i", "edit"} else None,
+                    expected_height=request.height if request.route in {"t2i", "edit"} else None,
+                )
+    samples = run_vlm_reviews(request, output_root, samples)
+
+    sample_rows = [sample.to_dict() for sample in samples]
+    write_jsonl(output_root / "manifest.jsonl", sample_rows)
+    write_json(
+        output_root / "dataset_summary.json",
+        {
+            "schema": "dataevolver_multimodal_dataset_summary_v1",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "route": request.route,
+            "dry_run": request.dry_run,
+            "generator": generator.name,
+            "sample_count": len(samples),
+            "status_counts": {
+                status: sum(1 for sample in samples if sample.status == status)
+                for status in sorted({sample.status for sample in samples})
+            },
+            "validation_counts": {
+                status: sum(1 for sample in samples if sample.validation.get("status") == status)
+                for status in sorted({sample.validation.get("status") for sample in samples if sample.validation})
+            },
+            "vlm_counts": {
+                status: sum(1 for sample in samples if sample.vlm_review.get("status") == status)
+                for status in sorted({sample.vlm_review.get("status") for sample in samples if sample.vlm_review})
+            },
+            "outputs": {
+                "request": "request.json",
+                "manifest": "manifest.jsonl",
+            },
+            "notes": request.notes,
+        },
+    )
+    return samples
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        request = build_request(
+            route=args.route,
+            user_request=args.user_request,
+            output_root=args.output_root,
+            dry_run=args.dry_run,
+            allow_model_inference=args.allow_model_inference,
+            num_samples=args.num_samples,
+            input_image_dir=args.input_image_dir,
+            prompt_file=args.prompt_file,
+            generator=args.generator,
+            model_name=args.model_name,
+            model_path=args.model_path,
+            device=args.device,
+            height=args.height,
+            width=args.width,
+            num_frames=args.num_frames,
+            fps=args.fps,
+            steps=args.steps,
+            true_cfg_scale=args.true_cfg_scale,
+            guidance_scale=args.guidance_scale,
+            negative_prompt=args.negative_prompt,
+            seed=args.seed,
+            sample_prefix=args.sample_prefix,
+            skip_existing=args.skip_existing,
+            validate_outputs=args.validate_outputs,
+            vlm_eval=args.vlm_eval,
+            vlm_device=args.vlm_device,
+            vlm_model_path=args.vlm_model_path,
+            vlm_max_samples=args.vlm_max_samples,
+            vlm_max_retries=args.vlm_max_retries,
+            vlm_review_mode=args.vlm_review_mode,
+            vlm_use_freeform_first=args.vlm_use_freeform_first,
+            vlm_enable_thinking=args.vlm_enable_thinking,
+        )
+        samples = run(request)
+    except Exception as exc:
+        raise SystemExit(f"[multimodal] ERROR: {exc}") from exc
+
+    print(
+        f"[multimodal] route={request.route} dry_run={request.dry_run} "
+        f"samples={len(samples)} output_root={request.output_root}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/multimodal/schemas.py
+++ b/pipeline/multimodal/schemas.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+SUPPORTED_ROUTES = {"t2i", "edit", "blender", "t2v"}
+
+
+@dataclass
+class DatasetRequest:
+    route: str
+    user_request: str
+    output_root: str
+    dry_run: bool
+    allow_model_inference: bool = False
+    num_samples: int = 4
+    input_image_dir: Optional[str] = None
+    prompt_file: Optional[str] = None
+    generator: str = "dryrun"
+    model_name: Optional[str] = None
+    model_path: Optional[str] = None
+    device: str = "cuda:0"
+    height: int = 512
+    width: int = 512
+    num_frames: int = 49
+    fps: int = 16
+    steps: int = 30
+    true_cfg_scale: float = 4.0
+    guidance_scale: float = 1.0
+    negative_prompt: str = ""
+    seed: int = 11
+    sample_prefix: str = "sample"
+    skip_existing: bool = True
+    validate_outputs: bool = True
+    vlm_eval: bool = False
+    vlm_device: str = "cuda:0"
+    vlm_model_path: Optional[str] = None
+    vlm_max_samples: Optional[int] = None
+    vlm_max_retries: int = 1
+    vlm_review_mode: str = "studio"
+    vlm_use_freeform_first: bool = False
+    vlm_enable_thinking: bool = False
+    status: str = "planned"
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class DatasetSample:
+    sample_id: str
+    route: str
+    prompt: str
+    output_path: Optional[str]
+    input_path: Optional[str] = None
+    edit_instruction: Optional[str] = None
+    generator: str = "dryrun"
+    status: str = "generated"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    validation: Dict[str, Any] = field(default_factory=dict)
+    vlm_review: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def normalize_route(route: str) -> str:
+    normalized = (route or "").strip().lower().replace("-", "_")
+    aliases = {
+        "text_to_image": "t2i",
+        "text2image": "t2i",
+        "image_edit": "edit",
+        "i2i_edit": "edit",
+        "t_i_to_i": "edit",
+        "3d": "blender",
+        "blender_3d": "blender",
+        "text_to_video": "t2v",
+        "text2video": "t2v",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in SUPPORTED_ROUTES:
+        raise ValueError(f"Unsupported route '{route}'. Expected one of: {sorted(SUPPORTED_ROUTES)}")
+    return normalized
+
+
+def relpath(path: Optional[Path], root: Path) -> Optional[str]:
+    if path is None:
+        return None
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path)

--- a/pipeline/multimodal/t2i_constraint_review.py
+++ b/pipeline/multimodal/t2i_constraint_review.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .t2i_constraints import constraints_for_prompt, normalize_constraint_review
+
+
+def _build_constraint_review_prompt(
+    *,
+    sample_id: str,
+    round_idx: int,
+    original_prompt: str,
+    rewritten_prompt: str,
+    constraints: list[dict],
+) -> tuple[str, str]:
+    schema = {
+        "schema_version": "t2i_constraint_review_v1",
+        "sample_id": sample_id,
+        "round_idx": round_idx,
+        "vlm_route": "<pass|needs_fix|reject>",
+        "constraint_checklist": [
+            {
+                "constraint_id": "<id from provided checklist>",
+                "type": "<constraint type>",
+                "description": "<constraint being checked>",
+                "status": "<pass|fail|uncertain>",
+                "evidence": "<short visual evidence, not reasoning>",
+                "confidence": "<low|medium|high>",
+            }
+        ],
+        "failed_constraints": ["<constraint_id>"],
+        "uncertain_constraints": ["<constraint_id>"],
+        "passed_constraints": ["<constraint_id>"],
+        "rewrite_suggestions": ["<specific prompt rewrite suggestion>"],
+        "summary": "<one sentence>",
+    }
+    system_msg = (
+        "You are a strict text-to-image dataset constraint reviewer. "
+        "You must judge the image against a prompt-derived checklist before giving any overall route. "
+        "Return ONLY a valid JSON object with no markdown fences or extra text. "
+        "The first character must be '{' and the last character must be '}'."
+    )
+    user_msg = (
+        f"sample_id={sample_id}, round_idx={round_idx}\n\n"
+        f"Original prompt:\n{original_prompt}\n\n"
+        f"Prompt used for this generated image:\n{rewritten_prompt}\n\n"
+        "Provided constraint checklist. Use every item; do not drop constraints. "
+        "You may add an extra checklist item only if the prompt has an obvious missing constraint, but prefer the provided ids.\n"
+        f"{json.dumps(constraints, indent=2, ensure_ascii=False)}\n\n"
+        "Review procedure:\n"
+        "1. First inspect each checklist item independently.\n"
+        "2. Mark status=pass only when the image visibly satisfies the constraint.\n"
+        "3. Mark status=fail when the image visibly violates the constraint or the required element is missing.\n"
+        "4. Mark status=uncertain when the image is ambiguous, too small, occluded beyond inspection, or not enough evidence exists.\n"
+        "5. Set vlm_route=pass only if all checklist items pass. Use needs_fix if any item fails or is uncertain. "
+        "Use reject only for blank images, unusable images, or a fundamentally wrong scene.\n"
+        "6. rewrite_suggestions must name the exact failed/uncertain constraints to repair.\n\n"
+        "JSON schema to return:\n"
+        f"{json.dumps(schema, indent=2, ensure_ascii=False)}"
+    )
+    return system_msg, user_msg
+
+
+def run_t2i_constraint_review(
+    *,
+    rgb_path: str,
+    sample_id: str,
+    round_idx: int,
+    original_prompt: str,
+    rewritten_prompt: str,
+    constraints: Optional[Iterable[dict]] = None,
+    device: str = "cuda:0",
+    max_retries: int = 2,
+    vlm_model_path: Optional[str] = None,
+    enable_thinking: bool = False,
+) -> dict:
+    normalized_constraints = constraints_for_prompt(original_prompt, constraints)
+    if vlm_model_path:
+        os.environ["VLM_MODEL_PATH"] = vlm_model_path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pipeline_dir = repo_root / "pipeline"
+    import sys
+
+    if str(pipeline_dir) not in sys.path:
+        sys.path.insert(0, str(pipeline_dir))
+
+    try:
+        import torch
+        from qwen_vl_utils import process_vision_info
+        from pipeline.stage5_5_vlm_review import _extract_json, load_vlm
+    except Exception as exc:
+        fallback = normalize_constraint_review({}, normalized_constraints)
+        fallback.update(
+            {
+                "sample_id": sample_id,
+                "round_idx": round_idx,
+                "original_prompt": original_prompt,
+                "rewritten_prompt": rewritten_prompt,
+                "review_backend": "t2i_constraint_import_fallback",
+                "parse_mode": "import_failed",
+                "error": str(exc),
+            }
+        )
+        return fallback
+
+    model, processor = load_vlm(device)
+    system_msg, user_msg = _build_constraint_review_prompt(
+        sample_id=sample_id,
+        round_idx=round_idx,
+        original_prompt=original_prompt,
+        rewritten_prompt=rewritten_prompt,
+        constraints=normalized_constraints,
+    )
+    content = [{"type": "image", "image": rgb_path}, {"type": "text", "text": user_msg}]
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": system_msg}]},
+        {"role": "user", "content": content},
+    ]
+    dialogue = {
+        "sample_id": sample_id,
+        "round_idx": round_idx,
+        "system_prompt": system_msg,
+        "user_prompt": user_msg,
+        "attempts": [],
+    }
+    for attempt in range(max(1, max_retries)):
+        try:
+            text_input = processor.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                chat_template_kwargs={"enable_thinking": bool(enable_thinking)},
+            )
+            text_input = text_input + "{"
+            image_inputs, video_inputs = process_vision_info(messages)
+            inputs = processor(
+                text=[text_input],
+                images=image_inputs,
+                videos=video_inputs,
+                padding=True,
+                return_tensors="pt",
+            ).to(device)
+            with torch.no_grad():
+                output_ids = model.generate(
+                    **inputs,
+                    max_new_tokens=2048,
+                    do_sample=False,
+                    temperature=None,
+                    top_p=None,
+                )
+            generated = output_ids[0][inputs.input_ids.shape[1] :]
+            text_out = "{" + processor.decode(generated, skip_special_tokens=True)
+            parsed = _extract_json(text_out)
+            dialogue["attempts"].append(
+                {
+                    "attempt": attempt + 1,
+                    "assistant_text": text_out,
+                    "parse_mode": "direct_json" if parsed is not None else "failed",
+                }
+            )
+            if parsed is not None:
+                review = normalize_constraint_review(parsed, normalized_constraints)
+                review.update(
+                    {
+                        "sample_id": sample_id,
+                        "round_idx": round_idx,
+                        "original_prompt": original_prompt,
+                        "rewritten_prompt": rewritten_prompt,
+                        "review_backend": "qwen_t2i_constraint_json",
+                        "parse_mode": "direct_json",
+                        "used_thinking": bool(enable_thinking),
+                        "vlm_dialogue": dialogue,
+                    }
+                )
+                return review
+        except Exception as exc:
+            dialogue["attempts"].append(
+                {
+                    "attempt": attempt + 1,
+                    "parse_mode": "exception",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+
+    fallback = normalize_constraint_review({}, normalized_constraints)
+    fallback.update(
+        {
+            "sample_id": sample_id,
+            "round_idx": round_idx,
+            "original_prompt": original_prompt,
+            "rewritten_prompt": rewritten_prompt,
+            "review_backend": "t2i_constraint_neutral_fallback",
+            "parse_mode": "neutral_fallback",
+            "used_thinking": bool(enable_thinking),
+            "vlm_dialogue": dialogue,
+        }
+    )
+    return fallback

--- a/pipeline/multimodal/t2i_constraints.py
+++ b/pipeline/multimodal/t2i_constraints.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+VALID_CONSTRAINT_STATUS = {"pass", "fail", "uncertain"}
+PASS_STATUS = "pass"
+FAIL_STATUS = "fail"
+UNCERTAIN_STATUS = "uncertain"
+
+
+def _constraint(constraint_id: str, kind: str, description: str) -> Dict[str, str]:
+    return {
+        "constraint_id": constraint_id,
+        "type": kind,
+        "description": description,
+    }
+
+
+def _spec(prompt_id: str, tier: str, prompt: str, constraints: List[Dict[str, str]]) -> Dict[str, object]:
+    return {
+        "id": prompt_id,
+        "tier": tier,
+        "prompt": prompt,
+        "constraints": constraints,
+    }
+
+
+def _simple_specs() -> List[Dict[str, object]]:
+    rows = [
+        ("simple_red_cube", "a single matte red cube centered on a light gray studio surface", "matte red cube"),
+        ("simple_blue_mug", "a single blue ceramic mug with one visible handle on a wooden tabletop", "blue ceramic mug"),
+        ("simple_yellow_ball", "a single yellow tennis ball with visible fuzzy texture on a clean table", "yellow tennis ball"),
+        ("simple_black_lamp", "a single black adjustable desk lamp with a round base on a plain desk", "black desk lamp"),
+        ("simple_glass_bottle", "a single transparent glass bottle with clear reflections on a neutral background", "transparent glass bottle"),
+        ("simple_green_toy_car", "a single green toy car with four visible wheels on a white tabletop", "green toy car"),
+        ("simple_silver_key", "a single silver metal key lying diagonally on dark fabric", "silver metal key"),
+        ("simple_orange_cone", "a single orange traffic cone with a white reflective band on gray concrete", "orange traffic cone"),
+        ("simple_wooden_spoon", "a single wooden spoon with visible grain on a linen cloth", "wooden spoon"),
+        ("simple_white_bowl", "a single white porcelain bowl casting a soft shadow on a beige table", "white porcelain bowl"),
+    ]
+    return [
+        _spec(
+            prompt_id,
+            "simple_object",
+            f"Create {prompt}. No readable text, logos, or watermark.",
+            [
+                _constraint("c_object_identity", "object_identity", f"The image shows {identity} as the main subject."),
+                _constraint("c_single_subject", "count", "There is exactly one main subject."),
+                _constraint("c_no_text", "text_ban", "There is no readable text, logo, label, or watermark."),
+            ],
+        )
+        for prompt_id, prompt, identity in rows
+    ]
+
+
+def _relation_spec(prompt_id: str, prompt: str, constraints: List[Tuple[str, str, str]]) -> Dict[str, object]:
+    return _spec(
+        prompt_id,
+        "compositional_relation",
+        f"Create {prompt}. Keep the layout easy to inspect and avoid readable text, logos, or watermarks.",
+        [_constraint(cid, kind, desc) for cid, kind, desc in constraints]
+        + [_constraint("c_no_text", "text_ban", "There is no readable text, logo, label, or watermark.")],
+    )
+
+
+def _relation_specs() -> List[Dict[str, object]]:
+    rows = [
+        (
+            "rel_mug_book_key",
+            "a blue mug to the left of a closed red book, with a silver key in front of the book",
+            [
+                ("c_left_right", "spatial_lr", "The blue mug is left of the red book."),
+                ("c_front", "spatial_depth", "The silver key is in front of the red book."),
+                ("c_objects", "object_identity", "The mug, red book, and silver key are all visible."),
+            ],
+        ),
+        (
+            "rel_bowl_lemon_spoon",
+            "a white bowl behind two yellow lemons, with a wooden spoon on the right side",
+            [
+                ("c_count", "count", "Exactly two yellow lemons are visible."),
+                ("c_depth", "spatial_depth", "The bowl is behind the lemons."),
+                ("c_right", "spatial_lr", "The wooden spoon is on the right side."),
+            ],
+        ),
+        (
+            "rel_camera_notebook_pen",
+            "a black camera in front of an open notebook, with a red pen crossing the notebook diagonally",
+            [
+                ("c_depth", "spatial_depth", "The black camera is in front of the open notebook."),
+                ("c_part", "part_detail", "The red pen crosses the notebook diagonally."),
+                ("c_objects", "object_identity", "The camera, notebook, and red pen are visible."),
+            ],
+        ),
+        (
+            "rel_three_vases",
+            "three small vases arranged left to right as blue, white, then green",
+            [
+                ("c_count", "count", "Exactly three small vases are visible."),
+                ("c_order", "spatial_lr", "The vases are ordered left to right as blue, white, then green."),
+                ("c_material", "material", "The vases look ceramic or glazed."),
+            ],
+        ),
+        (
+            "rel_lamp_toolbox_mug",
+            "a brass desk lamp behind a red toolbox, with a blue mug on the right",
+            [
+                ("c_depth", "spatial_depth", "The brass lamp is behind the red toolbox."),
+                ("c_right", "spatial_lr", "The blue mug is on the right side."),
+                ("c_material", "material", "The lamp reads as brass or warm metal."),
+            ],
+        ),
+        (
+            "rel_blocks_stack",
+            "four wooden blocks stacked as two on the bottom, one in the middle, and one on top",
+            [
+                ("c_count", "count", "Exactly four wooden blocks are visible."),
+                ("c_stack", "spatial_depth", "The blocks form a 2-1-1 vertical stack."),
+                ("c_material", "material", "The blocks have visible wood material."),
+            ],
+        ),
+        (
+            "rel_plate_fork_glass",
+            "a round white plate centered between a fork on the left and a clear glass on the right",
+            [
+                ("c_center", "composition", "The white plate is centered."),
+                ("c_left_right", "spatial_lr", "The fork is left of the plate and the glass is right of it."),
+                ("c_transparent", "transparent_reflective", "The glass is transparent with visible highlights."),
+            ],
+        ),
+        (
+            "rel_train_trees_bridge",
+            "a red toy train on a bridge, with pine trees behind the bridge and snow in the foreground",
+            [
+                ("c_depth", "spatial_depth", "Pine trees are behind the bridge."),
+                ("c_foreground", "spatial_depth", "Snow is visible in the foreground."),
+                ("c_subject", "object_identity", "The red toy train is on the bridge."),
+            ],
+        ),
+        (
+            "rel_robot_plants",
+            "a small white robot between two tall green plants inside a glass dome",
+            [
+                ("c_count", "count", "Exactly two tall green plants flank the robot."),
+                ("c_between", "spatial_lr", "The robot is between the two plants."),
+                ("c_glass", "transparent_reflective", "The glass dome is transparent or reflective."),
+            ],
+        ),
+        (
+            "rel_teapot_kettle_lemons",
+            "a white teapot in front of a copper kettle, with three lemon slices on the left",
+            [
+                ("c_depth", "spatial_depth", "The white teapot is in front of the copper kettle."),
+                ("c_count", "count", "Exactly three lemon slices are visible."),
+                ("c_left", "spatial_lr", "The lemon slices are on the left side."),
+            ],
+        ),
+        (
+            "rel_submarine_turtle_coral",
+            "a yellow submarine below a sea turtle and above red coral",
+            [
+                ("c_vertical", "spatial_depth", "The submarine is below the sea turtle and above the coral."),
+                ("c_objects", "object_identity", "The submarine, sea turtle, and red coral are all visible."),
+                ("c_water", "material", "The scene reads as underwater."),
+            ],
+        ),
+        (
+            "rel_tablet_window_astronaut",
+            "an astronaut near a window, with a glowing tablet floating to the astronaut's right",
+            [
+                ("c_right", "spatial_lr", "The glowing tablet is to the astronaut's right."),
+                ("c_window", "object_identity", "A window is visible near the astronaut."),
+                ("c_anatomy", "part_detail", "The astronaut has coherent limbs and helmet."),
+            ],
+        ),
+        (
+            "rel_terrarium_cottage_mushrooms",
+            "a glass terrarium containing a tiny cottage behind two red mushrooms",
+            [
+                ("c_count", "count", "Exactly two red mushrooms are visible."),
+                ("c_depth", "spatial_depth", "The tiny cottage is behind the mushrooms."),
+                ("c_glass", "transparent_reflective", "The terrarium glass edge or reflection is visible."),
+            ],
+        ),
+        (
+            "rel_cart_lanterns_steam",
+            "a food cart with two orange lanterns above it and steam rising behind the counter",
+            [
+                ("c_count", "count", "Exactly two orange lanterns are above the cart."),
+                ("c_depth", "spatial_depth", "Steam rises behind the counter area."),
+                ("c_subject", "object_identity", "The food cart is clearly visible."),
+            ],
+        ),
+        (
+            "rel_shelf_boxes_bottle",
+            "a shelf with a glass bottle in front of three cardboard boxes",
+            [
+                ("c_count", "count", "Exactly three cardboard boxes are visible."),
+                ("c_depth", "spatial_depth", "The glass bottle is in front of the boxes."),
+                ("c_transparent", "transparent_reflective", "The bottle is transparent or reflective."),
+            ],
+        ),
+        (
+            "rel_chair_table_laptop",
+            "a wooden chair behind a small table, with a closed silver laptop on the table",
+            [
+                ("c_depth", "spatial_depth", "The chair is behind the table."),
+                ("c_tabletop", "spatial_depth", "The silver laptop is on the table."),
+                ("c_material", "material", "The chair reads as wood."),
+            ],
+        ),
+        (
+            "rel_clock_books",
+            "a round clock leaning against two stacked books, with a candle on the left",
+            [
+                ("c_count", "count", "Exactly two stacked books are visible."),
+                ("c_left", "spatial_lr", "The candle is on the left side."),
+                ("c_contact", "spatial_depth", "The clock leans against the books."),
+            ],
+        ),
+        (
+            "rel_shoes_box",
+            "a pair of black shoes in front of an open cardboard box, with one shoe partly inside the box",
+            [
+                ("c_count", "count", "Exactly two black shoes are visible."),
+                ("c_depth", "spatial_depth", "The shoes are in front of the open box."),
+                ("c_occlusion", "occlusion", "One shoe is partly inside or occluded by the box."),
+            ],
+        ),
+        (
+            "rel_pencils_cup",
+            "five colored pencils inside a clear cup, with the red pencil at the front",
+            [
+                ("c_count", "count", "Exactly five colored pencils are visible."),
+                ("c_front", "spatial_depth", "The red pencil is at the front."),
+                ("c_cup", "transparent_reflective", "The cup is clear or transparent."),
+            ],
+        ),
+        (
+            "rel_watch_strap",
+            "a silver wristwatch with the strap open, placed below a folded blue cloth",
+            [
+                ("c_depth", "spatial_depth", "The watch is below the folded blue cloth."),
+                ("c_part", "part_detail", "The watch strap is open and visible."),
+                ("c_material", "material", "The watch reads as silver metal."),
+            ],
+        ),
+    ]
+    return [_relation_spec(*row) for row in rows]
+
+
+_COUNT_WORDS = {
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+}
+
+
+def _hard_spec(
+    prompt_id: str,
+    subject: str,
+    count: int,
+    material: str,
+    left_obj: str,
+    right_obj: str,
+    front_obj: str,
+    back_obj: str,
+    occluder: str,
+    part_detail: str,
+    distractor: str,
+) -> Dict[str, object]:
+    count_word = _COUNT_WORDS[count]
+    other_count = _COUNT_WORDS.get(count - 1, str(count - 1))
+    prompt = (
+        f"Create a high-difficulty verification scene with exactly {count_word} {material} {subject}s as the primary subjects. "
+        f"Place {left_obj} on the left and {right_obj} on the right; put {front_obj} in front of the {subject}s and {back_obj} behind them. "
+        f"The {occluder} must partially occlude only the rightmost {subject}, leaving the other {other_count} fully visible. "
+        f"Each {subject} must show {part_detail}. Include {distractor} in the background as same-color distractors that must not be counted as primary {subject}s. "
+        "Show clear transparent or reflective behavior where appropriate, use realistic material cues, and avoid readable text, logos, labels, or watermarks."
+    )
+    return _spec(
+        prompt_id,
+        "hard_constraints",
+        prompt,
+        [
+            _constraint("c_count_primary", "count", f"Exactly {count_word} primary {subject}s are visible."),
+            _constraint("c_left_right_anchors", "spatial_lr", f"{left_obj} is on the left and {right_obj} is on the right."),
+            _constraint("c_front_back_anchors", "spatial_depth", f"{front_obj} is in front of the {subject}s and {back_obj} is behind them."),
+            _constraint("c_controlled_occlusion", "occlusion", f"The {occluder} occludes only the rightmost {subject}."),
+            _constraint("c_primary_material", "material", f"The primary {subject}s read as {material}."),
+            _constraint("c_no_text", "text_ban", "No readable text, logos, labels, or watermarks are present."),
+            _constraint("c_transparent_reflective", "transparent_reflective", "Transparent or reflective behavior is visible where appropriate."),
+            _constraint("c_local_parts", "part_detail", f"Each primary {subject} shows {part_detail}."),
+            _constraint("c_same_color_distractor", "same_color_distractor", f"The {distractor} are visible but not counted as primary {subject}s."),
+        ],
+    )
+
+
+def _hard_specs() -> List[Dict[str, object]]:
+    rows = [
+        ("hard_glass_bottles", "bottle", 3, "cobalt-blue transparent glass", "a matte black ruler", "a white ceramic cup", "a silver coin", "a folded gray notebook", "translucent tracing paper", "two narrow neck rings and a cork stopper", "blue glass marbles"),
+        ("hard_chrome_keys", "key", 4, "reflective chrome metal", "a red wax seal", "a black pen cap", "a small brass screw", "a dark velvet pouch", "a clear plastic strip", "round bow holes and individual teeth", "silver paper clips"),
+        ("hard_acrylic_blocks", "block", 3, "clear acrylic", "a green sticky note", "a blue eraser", "a copper washer", "a white grid card", "a smoky transparent sheet", "beveled edges and internal reflections", "clear ice-cube props"),
+        ("hard_ceramic_cups", "cup", 3, "glossy white ceramic", "a yellow lemon wedge", "a steel spoon", "a cinnamon stick", "a beige napkin", "a transparent glass plate", "visible handles and dark inner rims", "white ceramic saucers"),
+        ("hard_brass_lamps", "lamp", 2, "brushed brass metal", "a black notebook", "a red screwdriver", "a round washer", "a wooden block", "a translucent fabric strip", "visible hinges and power cords", "brass drawer knobs"),
+        ("hard_amber_vials", "vial", 4, "amber transparent glass", "a white dropper", "a blue cap", "a folded pipette wrapper", "a gray lab tray", "a clear measuring strip", "black caps and tiny shoulders", "amber glass beads"),
+        ("hard_black_cameras", "camera", 2, "matte black plastic and glass", "a red lens cloth", "a silver memory card", "a lens cap", "a white calibration card", "a transparent acrylic shield", "lens rings and shutter buttons", "black camera batteries"),
+        ("hard_metal_gears", "gear", 5, "brushed steel", "a blue caliper", "a red handled file", "a brass washer", "a dark tool roll", "a clear oil dropper", "distinct teeth and center holes", "steel washers"),
+        ("hard_green_bottles", "bottle", 3, "emerald green reflective glass", "a cork coaster", "a white funnel", "a silver bottle opener", "a linen towel", "a translucent plastic sleeve", "long necks and lip ridges", "green glass beads"),
+        ("hard_porcelain_bowls", "bowl", 3, "glossy porcelain", "a black chopstick rest", "a copper spoon", "a folded recipe card face-down", "a wooden tray", "a clear glass lid", "thin rims and visible inner curves", "white porcelain sauce dishes"),
+        ("hard_silver_watches", "watch", 2, "polished silver metal", "a navy cloth", "a black strap tool", "a tiny screw", "a gray display stand", "a transparent plastic cover", "crowns, lugs, and open straps", "silver coins"),
+        ("hard_red_toolboxes", "toolbox", 2, "glossy red painted metal", "a yellow tape measure", "a black clamp", "a loose screw", "a wooden crate", "a clear safety visor", "handles, latches, and corner wear", "red metal tins"),
+        ("hard_blue_tiles", "tile", 4, "glossy blue ceramic", "a white grout float", "a red sponge", "a silver spacer", "a gray backing board", "a transparent ruler", "beveled edges and grout gaps", "blue ceramic shards"),
+        ("hard_clear_terrariums", "terrarium", 2, "transparent glass", "a green moss tray", "a brass spray bottle", "a tiny mushroom", "a wooden desk rail", "a sheer cloth curtain", "glass seams, refraction, and lids", "clear glass jars"),
+        ("hard_copper_kettles", "kettle", 2, "reflective copper", "a white teapot", "a blue towel", "a lemon slice", "a dark stove grate", "a transparent steam guard", "spouts, handles, and black knobs", "copper measuring cups"),
+        ("hard_white_robots", "robot", 3, "smooth white plastic", "a green plant marker", "a blue watering can", "a small pebble", "a curved glass wall", "a translucent leaf", "round camera eyes and jointed arms", "white plant pots"),
+        ("hard_yellow_submarines", "submarine", 2, "glossy yellow metal", "a red coral branch", "a blue shell", "a small anchor", "a dark reef arch", "a translucent bubble curtain", "round portholes and tail fins", "yellow reef fish"),
+        ("hard_silver_tablets", "tablet", 3, "reflective silver glass", "a black stylus", "a blue cable", "a microfiber cloth", "a white docking stand", "a clear screen protector", "thin bezels and side buttons", "silver metal plates"),
+        ("hard_crystal_perfume", "perfume bottle", 3, "transparent crystal glass", "a pink ribbon", "a black atomizer bulb", "a pearl bead", "a mirrored tray", "a translucent silk scarf", "spray nozzles and faceted stoppers", "clear crystal beads"),
+        ("hard_orange_cones", "traffic cone", 4, "orange rubber with reflective bands", "a gray wrench", "a blue glove", "a pebble", "a concrete curb", "a transparent rain sheet", "white bands and square bases", "orange rubber caps"),
+    ]
+    return [_hard_spec(*row) for row in rows]
+
+
+def get_prompt_bank() -> List[Dict[str, object]]:
+    return _simple_specs() + _relation_specs() + _hard_specs()
+
+
+def prompt_bank_counts() -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for spec in get_prompt_bank():
+        tier = str(spec["tier"])
+        counts[tier] = counts.get(tier, 0) + 1
+    return counts
+
+
+def select_prompt_specs(tier: Optional[str] = None, prompt_id: Optional[str] = None) -> List[Dict[str, object]]:
+    specs = get_prompt_bank()
+    if tier and tier != "all":
+        specs = [spec for spec in specs if spec["tier"] == tier]
+    if prompt_id:
+        specs = [spec for spec in specs if spec["id"] == prompt_id]
+    return deepcopy(specs)
+
+
+def write_prompt_bank(path: Path, tier: Optional[str] = None) -> None:
+    specs = select_prompt_specs(tier=tier)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(specs, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def normalize_constraints(constraints: Optional[Iterable[dict]]) -> List[Dict[str, str]]:
+    normalized: List[Dict[str, str]] = []
+    seen = set()
+    for idx, item in enumerate(constraints or []):
+        if not isinstance(item, dict):
+            continue
+        cid = str(item.get("constraint_id") or item.get("id") or f"c_{idx + 1:02d}").strip()
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        kind = str(item.get("type") or item.get("kind") or "prompt_alignment").strip()
+        desc = str(item.get("description") or item.get("constraint") or "").strip()
+        if not desc:
+            continue
+        normalized.append(_constraint(cid, kind, desc))
+    return normalized
+
+
+def infer_constraints_from_prompt(prompt: str) -> List[Dict[str, str]]:
+    text = " ".join((prompt or "").split())
+    lower = text.lower()
+    constraints = [
+        _constraint("c_prompt_alignment", "prompt_alignment", "The image follows the full original prompt."),
+    ]
+    if re.search(r"\b(exactly|only)\s+(one|two|three|four|five|six|\d+)\b", lower):
+        constraints.append(_constraint("c_count", "count", "The exact requested object count is satisfied."))
+    if " left " in f" {lower} " or " right " in f" {lower} ":
+        constraints.append(_constraint("c_left_right", "spatial_lr", "The requested left/right relationship is satisfied."))
+    if any(term in lower for term in ["in front of", "behind", "front", "back"]):
+        constraints.append(_constraint("c_front_back", "spatial_depth", "The requested front/back relationship is satisfied."))
+    if any(term in lower for term in ["occlude", "occludes", "occluded", "partially hidden", "partly inside"]):
+        constraints.append(_constraint("c_occlusion", "occlusion", "The requested occlusion relationship is satisfied."))
+    if any(term in lower for term in ["glass", "transparent", "reflective", "reflection", "mirror", "chrome", "metal"]):
+        constraints.append(_constraint("c_transparent_reflective", "transparent_reflective", "Transparent or reflective material cues are visible."))
+    if any(term in lower for term in ["handle", "ring", "cap", "button", "strap", "wheel", "edge", "rim", "teeth", "porthole"]):
+        constraints.append(_constraint("c_local_parts", "part_detail", "The requested local part details are visible."))
+    if any(term in lower for term in ["no text", "no readable", "no logos", "no logo", "watermark", "avoid text"]):
+        constraints.append(_constraint("c_no_text", "text_ban", "No readable text, logos, labels, or watermarks are present."))
+    return constraints
+
+
+def constraints_for_prompt(prompt: str, explicit_constraints: Optional[Iterable[dict]] = None) -> List[Dict[str, str]]:
+    explicit = normalize_constraints(explicit_constraints)
+    return explicit if explicit else infer_constraints_from_prompt(prompt)
+
+
+def normalize_constraint_review(review: Optional[dict], constraints: List[Dict[str, str]]) -> Dict[str, object]:
+    review = review if isinstance(review, dict) else {}
+    by_id = {item["constraint_id"]: item for item in constraints}
+    checklist_rows = review.get("constraint_checklist")
+    if not isinstance(checklist_rows, list):
+        checklist_rows = []
+    normalized_rows = []
+    seen = set()
+    for item in checklist_rows:
+        if not isinstance(item, dict):
+            continue
+        cid = str(item.get("constraint_id") or item.get("id") or "").strip()
+        if not cid:
+            continue
+        base = by_id.get(cid, _constraint(cid, str(item.get("type") or "prompt_alignment"), str(item.get("description") or "")))
+        status = str(item.get("status") or "").strip().lower()
+        if status not in VALID_CONSTRAINT_STATUS:
+            status = UNCERTAIN_STATUS
+        normalized_rows.append(
+            {
+                "constraint_id": cid,
+                "type": str(item.get("type") or base["type"]),
+                "description": str(item.get("description") or base["description"]),
+                "status": status,
+                "evidence": str(item.get("evidence") or "").strip(),
+                "confidence": str(item.get("confidence") or "medium").strip().lower()
+                if str(item.get("confidence") or "medium").strip().lower() in {"low", "medium", "high"}
+                else "medium",
+            }
+        )
+        seen.add(cid)
+    for constraint in constraints:
+        if constraint["constraint_id"] not in seen:
+            normalized_rows.append(
+                {
+                    **constraint,
+                    "status": UNCERTAIN_STATUS,
+                    "evidence": "Constraint was not explicitly judged by the reviewer.",
+                    "confidence": "low",
+                }
+            )
+    failed = [row for row in normalized_rows if row["status"] == FAIL_STATUS]
+    uncertain = [row for row in normalized_rows if row["status"] == UNCERTAIN_STATUS]
+    passed = [row for row in normalized_rows if row["status"] == PASS_STATUS]
+    route = str(review.get("vlm_route") or "").strip().lower()
+    if route not in {"pass", "needs_fix", "reject"}:
+        route = "pass" if not failed and not uncertain else "needs_fix"
+    if failed and route == "pass":
+        route = "needs_fix"
+    score = round(len(passed) / max(1, len(normalized_rows)), 4)
+    return {
+        **review,
+        "schema_version": "t2i_constraint_review_v1",
+        "vlm_route": route,
+        "constraint_checklist": normalized_rows,
+        "passed_constraints": [row["constraint_id"] for row in passed],
+        "failed_constraints": [row["constraint_id"] for row in failed],
+        "uncertain_constraints": [row["constraint_id"] for row in uncertain],
+        "constraint_status_counts": {
+            "pass": len(passed),
+            "fail": len(failed),
+            "uncertain": len(uncertain),
+            "total": len(normalized_rows),
+        },
+        "constraint_pass_rate": score,
+        "issue_tags": _issue_tags_from_constraints(failed, uncertain),
+        "scores": _scores_from_constraint_rate(score, failed, uncertain),
+    }
+
+
+def _issue_tags_from_constraints(failed: List[dict], uncertain: List[dict]) -> List[str]:
+    if not failed and not uncertain:
+        return ["none"]
+    tags = []
+    kinds = {str(row.get("type")) for row in failed + uncertain}
+    if "text_ban" in kinds:
+        tags.append("text_artifact")
+    if kinds - {"text_ban"}:
+        tags.append("prompt_constraint_miss")
+    return tags[:3] or ["prompt_constraint_miss"]
+
+
+def _scores_from_constraint_rate(score: float, failed: List[dict], uncertain: List[dict]) -> Dict[str, int]:
+    overall = max(1, min(5, round(score * 5)))
+    if failed:
+        overall = min(overall, 3)
+    elif uncertain:
+        overall = min(overall, 4)
+    return {
+        "lighting": 3,
+        "object_integrity": overall,
+        "composition": overall,
+        "render_quality_semantic": overall,
+        "overall": overall,
+    }
+
+
+def failed_constraint_rows(review: dict) -> List[Dict[str, object]]:
+    checklist = review.get("constraint_checklist") or []
+    return [row for row in checklist if isinstance(row, dict) and row.get("status") == FAIL_STATUS]
+
+
+def uncertain_constraint_rows(review: dict) -> List[Dict[str, object]]:
+    checklist = review.get("constraint_checklist") or []
+    return [row for row in checklist if isinstance(row, dict) and row.get("status") == UNCERTAIN_STATUS]
+
+
+def constraint_status_map(review: dict) -> Dict[str, str]:
+    return {
+        str(row.get("constraint_id")): str(row.get("status"))
+        for row in review.get("constraint_checklist", [])
+        if isinstance(row, dict) and row.get("constraint_id")
+    }
+
+
+def constraint_improvement(prev_review: dict, current_review: dict) -> Dict[str, object]:
+    prev_status = constraint_status_map(prev_review)
+    current_status = constraint_status_map(current_review)
+    previously_bad = {cid for cid, status in prev_status.items() if status in {FAIL_STATUS, UNCERTAIN_STATUS}}
+    improved = sorted(cid for cid in previously_bad if current_status.get(cid) == PASS_STATUS)
+    regressed = sorted(
+        cid
+        for cid, status in prev_status.items()
+        if status == PASS_STATUS and current_status.get(cid) in {FAIL_STATUS, UNCERTAIN_STATUS}
+    )
+    prev_bad_count = sum(1 for status in prev_status.values() if status in {FAIL_STATUS, UNCERTAIN_STATUS})
+    current_bad_count = sum(1 for status in current_status.values() if status in {FAIL_STATUS, UNCERTAIN_STATUS})
+    return {
+        "improved_constraints": improved,
+        "regressed_constraints": regressed,
+        "prev_bad_count": prev_bad_count,
+        "current_bad_count": current_bad_count,
+        "bad_count_delta": prev_bad_count - current_bad_count,
+        "has_improvement": bool(improved) and current_bad_count < prev_bad_count,
+    }
+
+
+def has_failure_then_improvement(events: List[dict]) -> Tuple[bool, Dict[str, object]]:
+    for idx in range(1, len(events)):
+        prev = events[idx - 1].get("review") or {}
+        current = events[idx].get("review") or {}
+        improvement = constraint_improvement(prev, current)
+        if improvement["has_improvement"]:
+            return True, {"from_round": idx - 1, "to_round": idx, **improvement}
+    return False, {}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Export the built-in T2I constraint prompt bank")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--tier", default="all", choices=["all", "simple_object", "compositional_relation", "hard_constraints"])
+    args = parser.parse_args()
+    write_prompt_bank(Path(args.output), tier=args.tier)

--- a/pipeline/multimodal/t2v_review.py
+++ b/pipeline/multimodal/t2v_review.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Optional
+
+from PIL import Image, ImageDraw, ImageSequence
+
+from .t2i_constraints import constraints_for_prompt
+from .t2i_constraint_review import run_t2i_constraint_review
+
+
+def _pil_from_array(frame) -> Image.Image:
+    if isinstance(frame, Image.Image):
+        return frame.convert("RGB")
+    return Image.fromarray(frame).convert("RGB")
+
+
+def _extract_gif_frames(path: Path) -> list[Image.Image]:
+    with Image.open(path) as img:
+        return [frame.copy().convert("RGB") for frame in ImageSequence.Iterator(img)]
+
+
+def _extract_imageio_frames(path: Path) -> list[Image.Image]:
+    try:
+        import imageio.v3 as iio
+
+        return [_pil_from_array(frame) for frame in iio.imiter(path)]
+    except Exception:
+        import imageio
+
+        reader = imageio.get_reader(str(path))
+        try:
+            return [_pil_from_array(frame) for frame in reader]
+        finally:
+            reader.close()
+
+
+def extract_keyframes(video_path: Path, frame_dir: Path, *, max_frames: int = 4) -> list[Path]:
+    video_path = Path(video_path)
+    frame_dir.mkdir(parents=True, exist_ok=True)
+    if video_path.suffix.lower() == ".gif":
+        frames = _extract_gif_frames(video_path)
+    else:
+        frames = _extract_imageio_frames(video_path)
+    if not frames:
+        raise ValueError(f"no frames decoded from video: {video_path}")
+    count = min(max(1, max_frames), len(frames))
+    if count == 1:
+        indices = [0]
+    else:
+        indices = sorted({round(i * (len(frames) - 1) / (count - 1)) for i in range(count)})
+    paths = []
+    for out_idx, frame_idx in enumerate(indices):
+        out_path = frame_dir / f"frame_{out_idx:02d}_src{frame_idx:04d}.png"
+        frames[frame_idx].save(out_path)
+        paths.append(out_path)
+    return paths
+
+
+def make_contact_sheet(frame_paths: list[Path], out_path: Path) -> Path:
+    images = [Image.open(path).convert("RGB") for path in frame_paths]
+    if not images:
+        raise ValueError("cannot build contact sheet without frames")
+    thumb_w = 320
+    pad = 12
+    thumbs = []
+    for img in images:
+        img.thumbnail((thumb_w, thumb_w), Image.Resampling.LANCZOS)
+        tile = Image.new("RGB", (thumb_w, thumb_w), (245, 245, 242))
+        tile.paste(img, ((thumb_w - img.width) // 2, (thumb_w - img.height) // 2))
+        draw = ImageDraw.Draw(tile)
+        draw.rectangle((0, 0, thumb_w - 1, thumb_w - 1), outline=(55, 60, 64), width=2)
+        thumbs.append(tile)
+    width = len(thumbs) * thumb_w + (len(thumbs) + 1) * pad
+    height = thumb_w + 2 * pad
+    sheet = Image.new("RGB", (width, height), (238, 238, 235))
+    for idx, tile in enumerate(thumbs):
+        sheet.paste(tile, (pad + idx * (thumb_w + pad), pad))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out_path)
+    return out_path
+
+
+def _video_constraints(original_prompt: str, constraints: Optional[Iterable[dict]]) -> list[dict]:
+    base = constraints_for_prompt(original_prompt, constraints)
+    existing = {str(row.get("constraint_id")) for row in base if isinstance(row, dict)}
+    extra = [
+        {
+            "constraint_id": "video_prompt_alignment",
+            "type": "prompt_alignment",
+            "description": "The keyframes collectively show the requested subject, setting, and action from the prompt.",
+        },
+        {
+            "constraint_id": "video_temporal_coherence",
+            "type": "temporal_coherence",
+            "description": "The subject identity, scene layout, lighting, and camera viewpoint remain coherent across frames.",
+        },
+        {
+            "constraint_id": "video_common_sense_motion",
+            "type": "physical_plausibility",
+            "description": "The visible motion is physically plausible and follows common sense for the requested scene.",
+        },
+        {
+            "constraint_id": "video_artifact_quality",
+            "type": "artifact_quality",
+            "description": "The frames avoid severe flicker, warped geometry, unusable blur, text artifacts, logos, or watermarks.",
+        },
+    ]
+    return base + [row for row in extra if row["constraint_id"] not in existing]
+
+
+def run_t2v_keyframe_review(
+    *,
+    video_path: str,
+    sample_id: str,
+    round_idx: int,
+    original_prompt: str,
+    rewritten_prompt: str,
+    constraints: Optional[Iterable[dict]] = None,
+    output_dir: str,
+    device: str = "cuda:0",
+    max_retries: int = 2,
+    vlm_model_path: Optional[str] = None,
+    enable_thinking: bool = False,
+) -> dict:
+    output = Path(output_dir)
+    frames_dir = output / "frames" / sample_id
+    contact_sheet = output / "contact_sheets" / f"{sample_id}_keyframes.png"
+    normalized_constraints = _video_constraints(original_prompt, constraints)
+    try:
+        frame_paths = extract_keyframes(Path(video_path), frames_dir, max_frames=4)
+        make_contact_sheet(frame_paths, contact_sheet)
+    except Exception as exc:
+        return {
+            "schema_version": "t2v_keyframe_review_v1",
+            "sample_id": sample_id,
+            "round_idx": round_idx,
+            "vlm_route": "needs_fix",
+            "status": "frame_extraction_failed",
+            "error": str(exc),
+            "video_path": video_path,
+            "constraint_checklist": normalized_constraints,
+            "failed_video_constraints": ["video_decode"],
+            "rewrite_suggestions": ["Regenerate a valid playable video file."],
+        }
+
+    review_prompt = (
+        "This image is a contact sheet of keyframes extracted from a generated text-to-video sample. "
+        "Judge the video by comparing these ordered frames against the original video prompt. "
+        "Treat temporal coherence, common-sense motion, and prompt alignment as first-class constraints. "
+        f"Original video prompt: {original_prompt}"
+    )
+    review = run_t2i_constraint_review(
+        rgb_path=str(contact_sheet),
+        sample_id=sample_id,
+        round_idx=round_idx,
+        original_prompt=review_prompt,
+        rewritten_prompt=rewritten_prompt,
+        constraints=normalized_constraints,
+        device=device,
+        max_retries=max_retries,
+        vlm_model_path=vlm_model_path,
+        enable_thinking=enable_thinking,
+    )
+    checklist = review.get("constraint_checklist") or []
+    counts = {
+        "pass": sum(1 for row in checklist if isinstance(row, dict) and row.get("status") == "pass"),
+        "fail": sum(1 for row in checklist if isinstance(row, dict) and row.get("status") == "fail"),
+        "uncertain": sum(1 for row in checklist if isinstance(row, dict) and row.get("status") == "uncertain"),
+        "total": len(checklist),
+    }
+    pass_rate = counts["pass"] / counts["total"] if counts["total"] else 0.0
+    review.update(
+        {
+            "schema_version": "t2v_keyframe_review_v1",
+            "video_path": video_path,
+            "keyframe_paths": [str(path) for path in frame_paths],
+            "contact_sheet_path": str(contact_sheet),
+            "video_checklist": checklist,
+            "video_status_counts": counts,
+            "video_pass_rate": pass_rate,
+            "failed_video_constraints": review.get("failed_constraints", []),
+            "uncertain_video_constraints": review.get("uncertain_constraints", []),
+            "passed_video_constraints": review.get("passed_constraints", []),
+            "review_backend": "t2v_keyframe_contact_sheet_vlm",
+        }
+    )
+    return review

--- a/pipeline/multimodal/validation.py
+++ b/pipeline/multimodal/validation.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+import struct
+import subprocess
+
+
+def _luma(pixel: tuple[int, int, int]) -> float:
+    r, g, b = pixel
+    return 0.299 * r + 0.587 * g + 0.114 * b
+
+
+def _foreground_stats(img) -> Dict[str, object]:
+    rgb = img.convert("RGB")
+    width, height = rgb.size
+    sample_w = min(128, width)
+    sample_h = min(128, height)
+    small = rgb.resize((sample_w, sample_h))
+    pixels = list(small.getdata())
+    if not pixels:
+        return {}
+
+    border = []
+    for y in range(sample_h):
+        for x in range(sample_w):
+            if x in {0, sample_w - 1} or y in {0, sample_h - 1}:
+                border.append(pixels[y * sample_w + x])
+    if not border:
+        border = pixels
+    bg = tuple(sum(p[i] for p in border) / len(border) for i in range(3))
+
+    threshold_sq = 24.0 * 24.0
+    fg_points = []
+    for idx, pixel in enumerate(pixels):
+        dist_sq = sum((pixel[i] - bg[i]) ** 2 for i in range(3))
+        if dist_sq > threshold_sq:
+            x = idx % sample_w
+            y = idx // sample_w
+            fg_points.append((x, y, pixel))
+
+    fg_fraction = len(fg_points) / float(sample_w * sample_h)
+    result: Dict[str, object] = {
+        "estimated_background_rgb": [round(v, 3) for v in bg],
+        "foreground_fraction": round(fg_fraction, 5),
+    }
+    if fg_points:
+        xs = [p[0] for p in fg_points]
+        ys = [p[1] for p in fg_points]
+        cxs = [(p[0] + 0.5) / sample_w for p in fg_points]
+        cys = [(p[1] + 0.5) / sample_h for p in fg_points]
+        result.update(
+            {
+                "foreground_bbox_xyxy": [
+                    round(min(xs) / sample_w, 4),
+                    round(min(ys) / sample_h, 4),
+                    round((max(xs) + 1) / sample_w, 4),
+                    round((max(ys) + 1) / sample_h, 4),
+                ],
+                "foreground_center_xy": [
+                    round(sum(cxs) / len(cxs), 4),
+                    round(sum(cys) / len(cys), 4),
+                ],
+                "foreground_mean_rgb": [
+                    round(sum(p[2][i] for p in fg_points) / len(fg_points), 3)
+                    for i in range(3)
+                ],
+            }
+        )
+    return result
+
+
+def validate_image(path: Optional[Path], *, expected_width: int | None = None, expected_height: int | None = None) -> Dict[str, object]:
+    if path is None:
+        return {"status": "fail", "issues": ["missing_path"]}
+    issues = []
+    path = Path(path)
+    if not path.exists():
+        return {"status": "fail", "issues": ["missing_file"], "path": str(path)}
+    size = path.stat().st_size
+    if size < 1024:
+        issues.append("output_too_small")
+
+    result: Dict[str, object] = {"path": str(path), "file_size": size}
+    try:
+        from PIL import Image, ImageStat
+
+        with Image.open(path) as img:
+            img.load()
+            width, height = img.size
+            result.update({"width": width, "height": height, "mode": img.mode})
+            if expected_width and width != expected_width:
+                issues.append("width_mismatch")
+            if expected_height and height != expected_height:
+                issues.append("height_mismatch")
+            stat = ImageStat.Stat(img.convert("RGB"))
+            means = [round(float(v), 3) for v in stat.mean]
+            stddev = [round(float(v), 3) for v in stat.stddev]
+            result.update({"mean_rgb": means, "stddev_rgb": stddev})
+            luma_mean = round(_luma(tuple(means)), 3)
+            result["luma_mean"] = luma_mean
+            result.update(_foreground_stats(img))
+            if max(stddev) < 1.0:
+                issues.append("low_information_image")
+            if max(means) < 3.0:
+                issues.append("near_black")
+            if min(means) > 252.0:
+                issues.append("near_white")
+            if luma_mean > 245.0 and max(stddev) < 18.0:
+                issues.append("washed_out_low_contrast")
+            foreground_fraction = float(result.get("foreground_fraction") or 0.0)
+            if foreground_fraction < 0.005:
+                issues.append("foreground_missing")
+            elif foreground_fraction < 0.035:
+                issues.append("foreground_too_small")
+            if foreground_fraction < 0.08 and luma_mean > 235.0:
+                issues.append("weak_subject_separation")
+    except Exception as exc:
+        parsed = False
+        try:
+            head = path.read_bytes()[:24]
+            if head.startswith(b"\x89PNG\r\n\x1a\n") and head[12:16] == b"IHDR":
+                width, height = struct.unpack(">II", head[16:24])
+                result.update({"width": int(width), "height": int(height), "mode": "unknown_png"})
+                if expected_width and width != expected_width:
+                    issues.append("width_mismatch")
+                if expected_height and height != expected_height:
+                    issues.append("height_mismatch")
+                parsed = True
+        except Exception:
+            parsed = False
+        if not parsed:
+            issues.append("image_open_failed")
+            result["error"] = str(exc)
+
+    result["issues"] = issues
+    result["status"] = "pass" if not issues else ("warn" if issues == ["output_too_small"] else "fail")
+    return result
+
+
+def _probe_gif(path: Path) -> Dict[str, object]:
+    from PIL import Image, ImageSequence
+
+    with Image.open(path) as img:
+        frames = [frame.copy().convert("RGB") for frame in ImageSequence.Iterator(img)]
+        width, height = img.size
+    result: Dict[str, object] = {
+        "container": "gif",
+        "width": width,
+        "height": height,
+        "num_frames": len(frames),
+    }
+    if frames:
+        first = frames[0]
+        result.update({"first_frame": validate_image(path, expected_width=width, expected_height=height)})
+        if len(frames) > 1:
+            result["has_multiple_frames"] = True
+    return result
+
+
+def _probe_with_imageio(path: Path) -> Dict[str, object]:
+    import imageio.v3 as iio
+
+    props = iio.improps(path)
+    meta = iio.immeta(path, exclude_applied=False)
+    shape = getattr(props, "shape", None)
+    result: Dict[str, object] = {"container": path.suffix.lower().lstrip(".") or "video"}
+    if shape and len(shape) >= 3:
+        result["num_frames"] = int(shape[0])
+        result["height"] = int(shape[1])
+        result["width"] = int(shape[2])
+    if meta:
+        result["metadata"] = {str(k): str(v) for k, v in list(meta.items())[:20]}
+    return result
+
+
+def _probe_with_ffprobe(path: Path) -> Dict[str, object]:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height,nb_frames,r_frame_rate,duration",
+        "-of",
+        "default=noprint_wrappers=1",
+        str(path),
+    ]
+    result = subprocess.run(cmd, text=True, capture_output=True, timeout=20)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "ffprobe failed")
+    parsed: Dict[str, object] = {"container": path.suffix.lower().lstrip(".") or "video"}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key in {"width", "height", "nb_frames"} and value.isdigit():
+            parsed["num_frames" if key == "nb_frames" else key] = int(value)
+        else:
+            parsed[key] = value
+    return parsed
+
+
+def validate_video(
+    path: Optional[Path],
+    *,
+    expected_width: int | None = None,
+    expected_height: int | None = None,
+    expected_num_frames: int | None = None,
+) -> Dict[str, object]:
+    if path is None:
+        return {"status": "fail", "issues": ["missing_path"]}
+    issues = []
+    path = Path(path)
+    if not path.exists():
+        return {"status": "fail", "issues": ["missing_file"], "path": str(path)}
+    size = path.stat().st_size
+    result: Dict[str, object] = {"path": str(path), "file_size": size}
+    small_file_threshold = 1024 if path.suffix.lower() == ".gif" else 4096
+    if size < small_file_threshold:
+        issues.append("output_too_small")
+    suffix = path.suffix.lower()
+    if suffix not in {".mp4", ".gif", ".webm", ".mov"}:
+        issues.append("unexpected_video_extension")
+
+    probe_errors = []
+    for probe in (
+        (_probe_gif if suffix == ".gif" else None),
+        _probe_with_imageio,
+        _probe_with_ffprobe,
+    ):
+        if probe is None:
+            continue
+        try:
+            result.update(probe(path))
+            break
+        except Exception as exc:
+            probe_errors.append(f"{getattr(probe, '__name__', 'probe')}: {exc}")
+    if "width" not in result or "height" not in result:
+        issues.append("video_metadata_unavailable")
+        result["probe_errors"] = probe_errors[-3:]
+
+    width = result.get("width")
+    height = result.get("height")
+    frames = result.get("num_frames")
+    if expected_width and isinstance(width, int) and width != expected_width:
+        issues.append("width_mismatch")
+    if expected_height and isinstance(height, int) and height != expected_height:
+        issues.append("height_mismatch")
+    if expected_num_frames and isinstance(frames, int) and frames < max(2, min(expected_num_frames, 8)):
+        issues.append("too_few_frames")
+
+    result["issues"] = issues
+    metadata_only_issues = {"video_metadata_unavailable"}
+    result["status"] = "pass" if not issues or set(issues) <= metadata_only_issues else "fail"
+    return result

--- a/pipeline/multimodal/vlm_review.py
+++ b/pipeline/multimodal/vlm_review.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+from .schemas import DatasetRequest, DatasetSample
+from .edit_review import run_edit_constraint_review
+from .t2i_constraint_review import run_t2i_constraint_review
+from .t2v_review import run_t2v_keyframe_review
+
+
+T2I_ISSUE_TAGS = [
+    "none",
+    "underexposed",
+    "overexposed",
+    "flat_lighting",
+    "weak_subject_separation",
+    "background_too_bright",
+    "background_too_dark",
+    "object_too_small",
+    "object_too_large",
+    "off_center_left",
+    "off_center_right",
+    "off_center_up",
+    "off_center_down",
+    "object_cutoff_left",
+    "object_cutoff_right",
+    "object_cutoff_top",
+    "object_cutoff_bottom",
+    "geometry_distortion",
+    "background_distracting",
+    "color_shift",
+    "physical_implausibility",
+    "text_artifact",
+    "logo_or_watermark",
+    "prompt_constraint_miss",
+]
+
+
+def _prompt_appendix(request: DatasetRequest, sample: DatasetSample) -> str:
+    base = (
+        f"Dataset route: {request.route}. User request: {request.user_request}. "
+        f"Prompt/instruction: {sample.edit_instruction or sample.prompt}. "
+        "Judge image quality and prompt/instruction alignment using the existing DataEvolver review schema."
+    )
+    if request.route == "t2i":
+        return (
+            base
+            + "\n\nThis is direct text-to-image generation, not 3D scene insertion. "
+            "The main acceptance criterion is whether a human can clearly see the requested subject, "
+            "with plausible geometry, correct dominant color, usable framing, and no blank/near-white canvas. "
+            "For a simple product/object prompt, accept clean synthetic or studio-rendered imagery if it is visually logical. "
+            "For a complex scene prompt, check that all major named elements, spatial relationships, material cues, "
+            "lighting constraints, and explicit negative constraints are followed. "
+            "Do not pass an image only because it is aesthetically strong; it must satisfy the prompt. "
+            "If the prompt forbids readable text, signs, logos, or watermarks and the image contains text-like or logo-like marks, "
+            "set vlm_route to needs_fix or reject and include text_artifact or logo_or_watermark. "
+            "If important requested objects or constraints are missing, include prompt_constraint_miss. "
+            "Use reject for blank images, severe overexposure, absent subject, wrong object type, or wrong dominant color. "
+            "Use needs_fix for visible but improvable images."
+        )
+    if request.route == "edit":
+        return (
+            base
+            + "\n\nThis is image editing. Judge instruction following, preservation of unrelated content, "
+            "edit locality, and whether the edited image remains coherent."
+        )
+    return base
+
+
+def run_vlm_reviews(request: DatasetRequest, output_root: Path, samples: List[DatasetSample]) -> List[DatasetSample]:
+    if not request.vlm_eval:
+        return samples
+
+    limit = request.vlm_max_samples if request.vlm_max_samples is not None else len(samples)
+    review_dir = output_root / "vlm_reviews"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pipeline_dir = repo_root / "pipeline"
+    if str(pipeline_dir) not in sys.path:
+        sys.path.insert(0, str(pipeline_dir))
+    if request.vlm_model_path:
+        os.environ["VLM_MODEL_PATH"] = request.vlm_model_path
+
+    reviewed = 0
+    for sample in samples:
+        if reviewed >= limit:
+            sample.vlm_review = {
+                "status": "skipped",
+                "enabled": True,
+                "reason": "beyond --vlm-max-samples",
+            }
+            continue
+        if not sample.output_path:
+            sample.vlm_review = {"status": "skipped", "enabled": True, "reason": "missing output_path"}
+            continue
+        rgb_path = output_root / sample.output_path
+        if not rgb_path.exists():
+            sample.vlm_review = {"status": "skipped", "enabled": True, "reason": "output file missing"}
+            continue
+
+        if request.route == "t2i":
+            original_prompt = str(sample.metadata.get("original_prompt") or sample.prompt)
+            rewritten_prompt = str(sample.metadata.get("rewritten_prompt") or sample.prompt)
+            constraints = sample.metadata.get("constraints") or []
+            review = run_t2i_constraint_review(
+                rgb_path=str(rgb_path),
+                sample_id=sample.sample_id,
+                round_idx=0,
+                original_prompt=original_prompt,
+                rewritten_prompt=rewritten_prompt,
+                constraints=constraints,
+                device=request.vlm_device,
+                max_retries=request.vlm_max_retries,
+                vlm_model_path=request.vlm_model_path,
+                enable_thinking=request.vlm_enable_thinking,
+            )
+            path = review_dir / f"{sample.sample_id}_constraint_review.json"
+            path.write_text(json.dumps(review, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            sample.vlm_review = {
+                "status": "completed",
+                "enabled": True,
+                "review_path": str(path.relative_to(output_root)),
+                "vlm_route": review.get("vlm_route"),
+                "scores": review.get("scores", {}),
+                "issue_tags": review.get("issue_tags", []),
+                "constraint_checklist": review.get("constraint_checklist", []),
+                "constraint_status_counts": review.get("constraint_status_counts", {}),
+                "constraint_pass_rate": review.get("constraint_pass_rate"),
+                "failed_constraints": review.get("failed_constraints", []),
+                "uncertain_constraints": review.get("uncertain_constraints", []),
+                "passed_constraints": review.get("passed_constraints", []),
+                "rewrite_suggestions": review.get("rewrite_suggestions", []),
+                "backend": "pipeline.multimodal.t2i_constraint_review.run_t2i_constraint_review",
+            }
+            reviewed += 1
+            continue
+
+        if request.route == "edit":
+            if not sample.input_path:
+                sample.vlm_review = {"status": "skipped", "enabled": True, "reason": "missing input_path"}
+                continue
+            source_path = Path(sample.input_path)
+            if not source_path.exists():
+                sample.vlm_review = {"status": "skipped", "enabled": True, "reason": "source image missing"}
+                continue
+            edit_instruction = str(
+                sample.metadata.get("original_edit_instruction")
+                or sample.edit_instruction
+                or sample.prompt
+            )
+            constraints = sample.metadata.get("constraints") or []
+            review = run_edit_constraint_review(
+                edited_path=str(rgb_path),
+                source_path=str(source_path),
+                sample_id=sample.sample_id,
+                edit_instruction=edit_instruction,
+                constraints=constraints,
+                device=request.vlm_device,
+                max_retries=request.vlm_max_retries,
+                vlm_model_path=request.vlm_model_path,
+                enable_thinking=request.vlm_enable_thinking,
+            )
+            path = review_dir / f"{sample.sample_id}_edit_review.json"
+            path.write_text(json.dumps(review, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            sample.vlm_review = {
+                "status": "completed",
+                "enabled": True,
+                "review_path": str(path.relative_to(output_root)),
+                "vlm_route": review.get("vlm_route"),
+                "scores": review.get("scores", {}),
+                "issue_tags": review.get("issue_tags", []),
+                "edit_checklist": review.get("edit_checklist", []),
+                "constraint_checklist": review.get("constraint_checklist", []),
+                "edit_status_counts": review.get("edit_status_counts", {}),
+                "edit_pass_rate": review.get("edit_pass_rate"),
+                "failed_edit_constraints": review.get("failed_edit_constraints", []),
+                "uncertain_edit_constraints": review.get("uncertain_edit_constraints", []),
+                "passed_edit_constraints": review.get("passed_edit_constraints", []),
+                "rewrite_suggestions": review.get("rewrite_suggestions", []),
+                "backend": "pipeline.multimodal.edit_review.run_edit_constraint_review",
+            }
+            reviewed += 1
+            continue
+
+        if request.route == "t2v":
+            original_prompt = str(sample.metadata.get("original_prompt") or sample.prompt)
+            rewritten_prompt = str(sample.metadata.get("rewritten_prompt") or sample.prompt)
+            constraints = sample.metadata.get("constraints") or []
+            review = run_t2v_keyframe_review(
+                video_path=str(rgb_path),
+                sample_id=sample.sample_id,
+                round_idx=0,
+                original_prompt=original_prompt,
+                rewritten_prompt=rewritten_prompt,
+                constraints=constraints,
+                output_dir=str(review_dir),
+                device=request.vlm_device,
+                max_retries=request.vlm_max_retries,
+                vlm_model_path=request.vlm_model_path,
+                enable_thinking=request.vlm_enable_thinking,
+            )
+            path = review_dir / f"{sample.sample_id}_t2v_review.json"
+            path.write_text(json.dumps(review, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+            def _relative_or_none(value: object) -> object:
+                if not value:
+                    return value
+                try:
+                    return str(Path(str(value)).resolve().relative_to(output_root.resolve()))
+                except ValueError:
+                    return value
+
+            sample.vlm_review = {
+                "status": "completed",
+                "enabled": True,
+                "review_path": str(path.relative_to(output_root)),
+                "vlm_route": review.get("vlm_route"),
+                "scores": review.get("scores", {}),
+                "issue_tags": review.get("issue_tags", []),
+                "video_checklist": review.get("video_checklist", []),
+                "constraint_checklist": review.get("constraint_checklist", []),
+                "video_status_counts": review.get("video_status_counts", {}),
+                "video_pass_rate": review.get("video_pass_rate"),
+                "failed_video_constraints": review.get("failed_video_constraints", []),
+                "uncertain_video_constraints": review.get("uncertain_video_constraints", []),
+                "passed_video_constraints": review.get("passed_video_constraints", []),
+                "rewrite_suggestions": review.get("rewrite_suggestions", []),
+                "contact_sheet_path": _relative_or_none(review.get("contact_sheet_path")),
+                "keyframe_paths": [
+                    _relative_or_none(path_value)
+                    for path_value in (review.get("keyframe_paths") or [])
+                ],
+                "backend": "pipeline.multimodal.t2v_review.run_t2v_keyframe_review",
+            }
+            reviewed += 1
+            continue
+
+        from pipeline.stage5_5_vlm_review import run_vlm_review
+
+        appendix = _prompt_appendix(request, sample)
+        issue_tags_whitelist = T2I_ISSUE_TAGS if request.route == "t2i" else None
+        review = run_vlm_review(
+            str(rgb_path),
+            sample.sample_id,
+            0,
+            "image",
+            0,
+            0,
+            prev_rgb_path=sample.input_path,
+            device=request.vlm_device,
+            max_retries=request.vlm_max_retries,
+            prompt_appendix=appendix,
+            issue_tags_whitelist=issue_tags_whitelist,
+            review_mode=request.vlm_review_mode,
+            use_freeform_first=request.vlm_use_freeform_first,
+            enable_thinking=request.vlm_enable_thinking,
+        )
+        path = review_dir / f"{sample.sample_id}_vlm_review.json"
+        path.write_text(json.dumps(review, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        sample.vlm_review = {
+            "status": "completed",
+            "enabled": True,
+            "review_path": str(path.relative_to(output_root)),
+            "vlm_route": review.get("vlm_route"),
+            "scores": review.get("scores", {}),
+            "issue_tags": review.get("issue_tags", []),
+            "backend": "pipeline.stage5_5_vlm_review.run_vlm_review",
+        }
+        reviewed += 1
+    return samples

--- a/scripts/run_multimodal_edit_cloud.sh
+++ b/scripts/run_multimodal_edit_cloud.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-/home/jiazhuangzhuang/miniconda3/envs/aris/bin/python}"
+INPUT_IMAGE_DIR="${INPUT_IMAGE_DIR:?INPUT_IMAGE_DIR is required}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-${ROOT}/_tmp/multimodal_edit_dataset_cloud}"
+DEVICE="${DEVICE:-cuda:0}"
+MODEL_PATH="${QWEN_IMAGE_EDIT_MODEL_PATH:-/data/wuwenzhuo/Qwen-Image-Edit-2511}"
+USER_REQUEST="${USER_REQUEST:-Edit the main object while preserving background and layout}"
+NUM_SAMPLES="${NUM_SAMPLES:-5}"
+STEPS="${STEPS:-40}"
+HEIGHT="${HEIGHT:-512}"
+WIDTH="${WIDTH:-512}"
+PROMPT_FILE="${PROMPT_FILE:-}"
+VLM_EVAL="${VLM_EVAL:-0}"
+VLM_MAX_SAMPLES="${VLM_MAX_SAMPLES:-1}"
+VLM_MODEL_PATH="${VLM_MODEL_PATH:-/huggingface/model_hub/Qwen3.6-27B}"
+
+cmd=(
+  "$PYTHON_BIN" "$ROOT/pipeline/multimodal/run_multimodal_dataset.py"
+  --route edit
+  --user-request "$USER_REQUEST"
+  --input-image-dir "$INPUT_IMAGE_DIR"
+  --output-root "$OUTPUT_ROOT"
+  --generator qwen-image-edit
+  --allow-model-inference
+  --model-path "$MODEL_PATH"
+  --device "$DEVICE"
+  --height "$HEIGHT"
+  --width "$WIDTH"
+  --steps "$STEPS"
+  --num-samples "$NUM_SAMPLES"
+)
+
+if [[ -n "$PROMPT_FILE" ]]; then
+  cmd+=(--prompt-file "$PROMPT_FILE")
+fi
+if [[ "$VLM_EVAL" == "1" ]]; then
+  cmd+=(
+    --vlm-eval
+    --vlm-device "$DEVICE"
+    --vlm-model-path "$VLM_MODEL_PATH"
+    --vlm-max-samples "$VLM_MAX_SAMPLES"
+  )
+fi
+
+echo "[run_multimodal_edit_cloud] ${cmd[*]}"
+"${cmd[@]}"

--- a/scripts/run_multimodal_t2i_cloud.sh
+++ b/scripts/run_multimodal_t2i_cloud.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-/home/jiazhuangzhuang/miniconda3/envs/aris/bin/python}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-${ROOT}/_tmp/multimodal_t2i_dataset_cloud}"
+DEVICE="${DEVICE:-cuda:0}"
+MODEL_PATH="${QWEN_IMAGE_MODEL_PATH:-/data/wuwenzhuo/Qwen-Image-2512}"
+USER_REQUEST="${USER_REQUEST:-Generate clean product-style daily object images on simple backgrounds}"
+NUM_SAMPLES="${NUM_SAMPLES:-5}"
+STEPS="${STEPS:-8}"
+HEIGHT="${HEIGHT:-512}"
+WIDTH="${WIDTH:-512}"
+PROMPT_FILE="${PROMPT_FILE:-}"
+VLM_EVAL="${VLM_EVAL:-0}"
+VLM_MAX_SAMPLES="${VLM_MAX_SAMPLES:-1}"
+
+cmd=(
+  "$PYTHON_BIN" "$ROOT/pipeline/multimodal/run_multimodal_dataset.py"
+  --route t2i
+  --user-request "$USER_REQUEST"
+  --output-root "$OUTPUT_ROOT"
+  --generator qwen-image
+  --allow-model-inference
+  --model-path "$MODEL_PATH"
+  --device "$DEVICE"
+  --height "$HEIGHT"
+  --width "$WIDTH"
+  --steps "$STEPS"
+  --num-samples "$NUM_SAMPLES"
+)
+
+if [[ -n "$PROMPT_FILE" ]]; then
+  cmd+=(--prompt-file "$PROMPT_FILE")
+fi
+if [[ "$VLM_EVAL" == "1" ]]; then
+  cmd+=(--vlm-eval --vlm-device "$DEVICE" --vlm-max-samples "$VLM_MAX_SAMPLES")
+fi
+
+echo "[run_multimodal_t2i_cloud] ${cmd[*]}"
+"${cmd[@]}"

--- a/scripts/run_multimodal_t2i_vlm_loop.py
+++ b/scripts/run_multimodal_t2i_vlm_loop.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pipeline.multimodal.t2i_constraints import (
+    constraint_improvement,
+    constraints_for_prompt,
+    failed_constraint_rows,
+    has_failure_then_improvement,
+    select_prompt_specs,
+    uncertain_constraint_rows,
+    write_prompt_bank,
+)
+
+
+DEFAULT_PYTHON = "/home/jiazhuangzhuang/miniconda3/envs/aris/bin/python"
+DEFAULT_MODEL = "/data/wuwenzhuo/Qwen-Image-2512"
+DEFAULT_VLM_MODEL = "/huggingface/model_hub/Qwen3.6-27B"
+COMPLEX_SCENE_TERMS = [
+    "scene", "interior", "exterior", "environment", "street", "market", "night market",
+    "greenhouse", "underwater", "submarine", "coral", "forest", "city", "kitchen",
+    "counter", "workbench", "desk", "table", "bridge", "train", "space station",
+    "astronaut", "terrarium", "landscape", "crowd", "shoppers", "vendors", "shelves",
+    "background elements", "detailed background", "busy background", "foreground and background",
+    "surrounded by", "beside", "next to", "behind",
+    "in front of", "include", "including", "several", "multiple", "many",
+    "场景", "室内", "室外", "街道", "市场", "夜市", "温室", "水下", "珊瑚", "森林",
+    "城市", "厨房", "台面", "工作台", "桌面", "桥", "火车", "空间站", "宇航员",
+    "玻璃缸", "背景元素", "详细背景", "复杂背景", "前景和背景", "周围", "旁边", "后面",
+    "包括", "多个", "许多",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run a T2I -> old VLM review prompt refinement loop")
+    p.add_argument("--output-root", required=True)
+    p.add_argument("--initial-request", default=None)
+    p.add_argument("--prompt-id", default=None, help="Use one built-in constraint prompt by id")
+    p.add_argument(
+        "--prompt-tier",
+        default=None,
+        choices=["simple_object", "compositional_relation", "hard_constraints"],
+        help="When --prompt-id is omitted, pick the first prompt from this built-in tier",
+    )
+    p.add_argument("--write-prompt-bank", default=None, help="Write the built-in 10/20/20 prompt bank JSON and continue")
+    p.add_argument("--max-rounds", type=int, default=5)
+    p.add_argument("--python", default=DEFAULT_PYTHON)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--dry-run", action="store_true", help="Run the multimodal dry-run generator for local loop structure tests")
+    p.add_argument("--generator", default="qwen-image")
+    p.add_argument("--model-path", default=DEFAULT_MODEL)
+    p.add_argument("--vlm-model-path", default=DEFAULT_VLM_MODEL)
+    p.add_argument("--height", type=int, default=512)
+    p.add_argument("--width", type=int, default=512)
+    p.add_argument("--steps", type=int, default=30)
+    p.add_argument("--true-cfg-scale", type=float, default=4.0)
+    p.add_argument("--seed", type=int, default=9001)
+    p.add_argument("--sample-prefix", default="loop")
+    p.add_argument("--vlm-max-retries", type=int, default=2)
+    p.add_argument("--vlm-review-mode", default="studio")
+    p.add_argument("--vlm-use-freeform-first", dest="vlm_use_freeform_first", action="store_true", default=False)
+    p.add_argument("--vlm-json-only", dest="vlm_use_freeform_first", action="store_false")
+    p.add_argument("--vlm-enable-thinking", action="store_true")
+    p.add_argument("--stop-on-pass", action="store_true", default=True)
+    p.add_argument("--no-stop-on-pass", dest="stop_on_pass", action="store_false")
+    p.add_argument("--require-fail-then-improve", dest="require_fail_then_improve", action="store_true", default=True)
+    p.add_argument("--allow-one-round-pass", dest="require_fail_then_improve", action="store_false")
+    return p.parse_args()
+
+
+def read_jsonl(path: Path) -> List[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def compact_review(row: dict) -> dict:
+    review = row.get("vlm_review") or {}
+    validation = row.get("validation") or {}
+    return {
+        "vlm_route": review.get("vlm_route"),
+        "scores": review.get("scores", {}),
+        "issue_tags": review.get("issue_tags", []),
+        "constraint_checklist": review.get("constraint_checklist", []),
+        "constraint_status_counts": review.get("constraint_status_counts", {}),
+        "constraint_pass_rate": review.get("constraint_pass_rate"),
+        "failed_constraints": review.get("failed_constraints", []),
+        "uncertain_constraints": review.get("uncertain_constraints", []),
+        "passed_constraints": review.get("passed_constraints", []),
+        "rewrite_suggestions": review.get("rewrite_suggestions", []),
+        "validation_status": validation.get("status"),
+        "validation_issues": validation.get("issues", []),
+        "mean_rgb": validation.get("mean_rgb"),
+        "luma_mean": validation.get("luma_mean"),
+        "foreground_fraction": validation.get("foreground_fraction"),
+        "foreground_bbox_xyxy": validation.get("foreground_bbox_xyxy"),
+        "output_path": row.get("output_path"),
+        "review_path": review.get("review_path"),
+    }
+
+
+def _infer_target(request: str) -> Tuple[str, str | None, str | None]:
+    text = request.strip()
+    lower = text.lower()
+    color = None
+    if "红" in text or "red" in lower:
+        color = "red"
+    elif "蓝" in text or "blue" in lower:
+        color = "blue"
+    elif "绿" in text or "green" in lower:
+        color = "green"
+    elif "黄" in text or "yellow" in lower:
+        color = "yellow"
+    elif "黑" in text or "black" in lower:
+        color = "black"
+    elif "白" in text or "white" in lower:
+        color = "white"
+
+    obj = None
+    if any(token in text for token in ["立方体", "方块", "正方体"]) or "cube" in lower:
+        obj = "cube"
+    elif "球" in text or "sphere" in lower or "ball" in lower:
+        obj = "sphere"
+    elif "杯" in text or "cup" in lower or "mug" in lower:
+        obj = "mug"
+
+    if color and obj:
+        return f"a single matte {color} {obj}", color, obj
+    if obj:
+        return f"a single clear {obj}", color, obj
+    return f"the requested subject: {request}", color, obj
+
+
+def _looks_complex_scene(request: str) -> bool:
+    text = request.strip()
+    lower = text.lower()
+    if any(term in lower for term in COMPLEX_SCENE_TERMS):
+        return True
+    comma_like_count = sum(text.count(sep) for sep in [",", "，", ";", "；"])
+    relation_count = sum(lower.count(term) for term in [" with ", " and ", " on ", " under ", " beside "])
+    return comma_like_count >= 3 or relation_count >= 4
+
+
+def _requests_text_or_logo(request: str) -> bool:
+    lower = request.lower()
+    negated_terms = [
+        "no text", "without text", "no readable", "without readable",
+        "no logo", "no logos", "without logo", "without logos",
+        "不要文字", "无文字", "没有文字", "不要logo", "无logo", "没有logo",
+    ]
+    if any(term in lower for term in negated_terms):
+        return False
+    return any(
+        term in lower
+        for term in [
+            "readable text", "legible text", "text that says", "sign that says",
+            "label reading", "readable label", "with the word", "spells",
+            "company logo", "brand logo", "with logo", "typography",
+            "文字内容", "写着", "标语写着", "标签写着", "徽标为",
+        ]
+    )
+
+
+def _refine_complex_scene_prompt(base_request: str, review: Dict[str, object], round_idx: int) -> str:
+    tags = set(review.get("issue_tags") or [])
+    issues = set(review.get("validation_issues") or [])
+    problems = tags | issues
+    scores = review.get("scores") or {}
+    prompt_parts = [
+        "Create a detailed, visually coherent dataset image that fully matches this scene request:",
+        base_request.strip(),
+        "Preserve all named subjects, objects, colors, materials, lighting cues, and spatial relationships from the request.",
+        "Use coherent perspective, natural depth, balanced exposure, visible shadows, and clear separation between foreground, midground, and background.",
+        "Keep the main focal elements easy to inspect while retaining the requested environment and supporting objects.",
+    ]
+    if not _requests_text_or_logo(base_request):
+        prompt_parts.append("Avoid readable text, fake lettering, logos, watermarks, and sign-like artifacts.")
+    if {"near_white", "washed_out_low_contrast", "foreground_missing", "weak_subject_separation"} & problems:
+        prompt_parts.append(
+            "Avoid overexposure and washed-out contrast; make the scene clearly visible with distinct silhouettes and tonal separation."
+        )
+    if {"object_too_small", "foreground_too_small"} & problems:
+        prompt_parts.append("Make the requested focal subjects larger and easier to inspect without removing the scene context.")
+    if "color_shift" in problems:
+        prompt_parts.append("Preserve the requested object colors and material colors accurately.")
+    if "geometry_distortion" in problems or scores.get("object_integrity", 3) <= 2:
+        prompt_parts.append("Prioritize stable geometry, consistent anatomy, and physically plausible object structure.")
+    if {"text_artifact", "logo_or_watermark", "prompt_constraint_miss"} & problems:
+        prompt_parts.append("Strictly satisfy negative constraints from the request, especially no-text, no-logo, and no-watermark constraints.")
+    if round_idx > 0:
+        prompt_parts.append(f"This is revision {round_idx}; correct the previous issues while preserving the original complex scene request.")
+    return " ".join(prompt_parts)
+
+
+def refine_prompt(base_request: str, review: Dict[str, object] | None, round_idx: int) -> str:
+    review = review or {}
+    tags = set(review.get("issue_tags") or [])
+    issues = set(review.get("validation_issues") or [])
+    problems = tags | issues
+    scores = review.get("scores") or {}
+    if _looks_complex_scene(base_request):
+        return _refine_complex_scene_prompt(base_request, review, round_idx)
+    target, color, obj = _infer_target(base_request)
+
+    background = "an off-white or very light gray studio background, not a pure white blank canvas"
+    if "白" in base_request or "white" in base_request.lower():
+        background = "an off-white studio background that reads as white but still has visible tonal separation"
+
+    prompt_parts = [
+        f"Create one visually logical dataset image of {target}.",
+        "The subject is centered and large, occupying about 45-60 percent of the frame.",
+        f"Use {background}.",
+        "Use balanced exposure, moderate contrast, and a visible soft shadow under the subject.",
+        "No text, watermark, extra objects, abstract blur, blank canvas, or low-contrast washed-out result.",
+    ]
+    if obj == "cube":
+        prompt_parts.append(
+            "The cube has crisp straight edges, three visible square faces, coherent perspective, and a solid 3D form."
+        )
+    if color == "red":
+        prompt_parts.append("The dominant object color is saturated matte red, not green, gray, pink, or yellow.")
+    elif color:
+        prompt_parts.append(f"The dominant object color is clearly {color}.")
+
+    if {"near_white", "washed_out_low_contrast", "foreground_missing", "weak_subject_separation"} & problems:
+        prompt_parts.append(
+            "Avoid overexposure: keep the background below pure white, add edge separation, and make the object clearly visible."
+        )
+    if {"object_too_small", "foreground_too_small"} & problems:
+        prompt_parts.append("Make the subject much larger and easier to inspect.")
+    if "color_shift" in problems and color:
+        prompt_parts.append(f"Correct the color shift: the subject must be {color}.")
+    if "geometry_distortion" in problems or scores.get("object_integrity", 3) <= 2:
+        prompt_parts.append("Prioritize simple stable geometry over decorative texture.")
+    if "background_too_bright" in problems or "overexposed" in problems:
+        prompt_parts.append("Use a light gray floor/background gradient and avoid clipping highlights.")
+    if round_idx > 0:
+        prompt_parts.append(f"This is revision {round_idx}; ignore previous failed artifacts and regenerate cleanly from the request.")
+    return " ".join(prompt_parts)
+
+
+def build_rewrite(base_request: str, review: Dict[str, object] | None, round_idx: int) -> Tuple[str, str]:
+    review = review or {}
+    prompt = refine_prompt(base_request, review, round_idx)
+    repair_rows = failed_constraint_rows(review) + uncertain_constraint_rows(review)
+    if not repair_rows:
+        if round_idx == 0:
+            return prompt, "initial_prompt_rewrite: preserve the original request while making it dataset-oriented"
+        return prompt, "no_failed_constraints_available: regenerated from the original request"
+
+    repair_lines = []
+    for row in repair_rows:
+        repair_lines.append(
+            f"{row.get('constraint_id')}: {row.get('description')} (previous status={row.get('status')})"
+        )
+        kind = str(row.get("type") or "")
+        if kind == "text_ban":
+            repair_lines.append(
+                "text_ban repair detail: make every prop blank and unmarked; use a plain silver coin or disc "
+                "with no numerals, letters, logos, embossed symbols, labels, or readable ruler markings"
+            )
+        elif kind == "occlusion":
+            repair_lines.append(
+                "occlusion repair detail: put the occluding object physically in front of the named target, "
+                "covering only the requested target and not the other primary subjects"
+            )
+        elif kind == "part_detail":
+            repair_lines.append(
+                "part_detail repair detail: simplify local geometry so the requested parts are countable and unambiguous"
+            )
+    passed_ids = review.get("passed_constraints") or []
+    pass_rows = [
+        row
+        for row in review.get("constraint_checklist", [])
+        if isinstance(row, dict) and row.get("status") == "pass"
+    ]
+    preserve_lines = [
+        f"{row.get('constraint_id')}: {row.get('description')}"
+        for row in pass_rows[:12]
+        if row.get("constraint_id") and row.get("description")
+    ]
+    prompt = (
+        f"{prompt} Constraint repair checklist for this revision: "
+        + " ; ".join(repair_lines)
+        + ". Anti-regression checklist: preserve every previously passing constraint exactly"
+    )
+    if preserve_lines:
+        prompt += ": " + " ; ".join(preserve_lines)
+    elif passed_ids:
+        prompt += f" ({', '.join(str(x) for x in passed_ids[:8])})"
+    prompt += "."
+    return (
+        prompt,
+        "repair_failed_constraints: "
+        + "; ".join(str(row.get("constraint_id")) for row in repair_rows),
+    )
+
+
+def review_rank(review: Dict[str, object]) -> Tuple[int, int, float, float]:
+    route_score = {"pass": 3, "needs_fix": 2, "reject": 1}.get(str(review.get("vlm_route")), 0)
+    validation_score = 1 if review.get("validation_status") == "pass" else 0
+    constraint_rate = review.get("constraint_pass_rate")
+    if isinstance(constraint_rate, (int, float)):
+        return route_score, validation_score, float(constraint_rate) * 100.0, -float(
+            (review.get("constraint_status_counts") or {}).get("fail", 0)
+        )
+    scores = review.get("scores") or {}
+    score_sum = float(sum(float(v) for v in scores.values() if isinstance(v, (int, float))))
+    foreground = float(review.get("foreground_fraction") or 0.0)
+    return route_score, validation_score, score_sum, foreground
+
+
+def resolve_initial_prompt(args: argparse.Namespace) -> Tuple[str, List[dict], Dict[str, object]]:
+    if args.write_prompt_bank:
+        write_prompt_bank(Path(args.write_prompt_bank))
+    selected = []
+    if args.prompt_id or args.prompt_tier:
+        selected = select_prompt_specs(tier=args.prompt_tier, prompt_id=args.prompt_id)
+        if not selected:
+            raise SystemExit(f"No built-in prompt matched prompt_id={args.prompt_id!r}, prompt_tier={args.prompt_tier!r}")
+    if selected:
+        spec = selected[0]
+        prompt = str(spec["prompt"])
+        constraints = constraints_for_prompt(prompt, spec.get("constraints"))
+        return (
+            prompt,
+            constraints,
+            {
+                "tier": spec.get("tier"),
+                "source_prompt_id": spec.get("id"),
+                "prompt_bank_selected": True,
+            },
+        )
+    if not args.initial_request:
+        raise SystemExit("--initial-request is required unless --prompt-id or --prompt-tier is provided")
+    prompt = args.initial_request
+    return prompt, constraints_for_prompt(prompt), {"prompt_bank_selected": False}
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = REPO_ROOT
+    entrypoint = repo_root / "pipeline" / "multimodal" / "run_multimodal_dataset.py"
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    original_prompt, constraints, prompt_meta = resolve_initial_prompt(args)
+    prompt, rewrite_reason = build_rewrite(original_prompt, None, 0)
+    history = []
+    best_event = None
+    for round_idx in range(args.max_rounds):
+        round_dir = output_root / f"round_{round_idx:02d}"
+        sample_id = f"{args.sample_prefix}{round_idx:02d}_0001"
+        prompt_file = round_dir / "model_inputs" / "loop_prompt.json"
+        write_json(
+            prompt_file,
+            [
+                {
+                    "id": sample_id,
+                    "prompt": prompt,
+                    "original_prompt": original_prompt,
+                    "rewritten_prompt": prompt,
+                    "constraints": constraints,
+                    "rewrite_reason": rewrite_reason,
+                    "tier": prompt_meta.get("tier"),
+                    "source_prompt_id": prompt_meta.get("source_prompt_id"),
+                }
+            ],
+        )
+        generator = "dryrun" if args.dry_run and args.generator == "qwen-image" else args.generator
+        cmd = [
+            args.python,
+            str(entrypoint),
+            "--route",
+            "t2i",
+            "--user-request",
+            original_prompt,
+            "--output-root",
+            str(round_dir),
+            "--generator",
+            generator,
+            "--prompt-file",
+            str(prompt_file),
+            "--device",
+            args.device,
+            "--height",
+            str(args.height),
+            "--width",
+            str(args.width),
+            "--steps",
+            str(args.steps),
+            "--true-cfg-scale",
+            str(args.true_cfg_scale),
+            "--num-samples",
+            "1",
+            "--seed",
+            str(args.seed + round_idx),
+            "--sample-prefix",
+            f"{args.sample_prefix}{round_idx:02d}",
+            "--vlm-eval",
+            "--vlm-device",
+            args.device,
+            "--vlm-model-path",
+            args.vlm_model_path,
+            "--vlm-max-samples",
+            "1",
+            "--vlm-max-retries",
+            str(args.vlm_max_retries),
+            "--vlm-review-mode",
+            args.vlm_review_mode,
+            "--no-skip-existing",
+        ]
+        if args.dry_run:
+            cmd.append("--dry-run")
+        else:
+            cmd.extend(["--allow-model-inference", "--model-path", args.model_path])
+        if args.vlm_use_freeform_first:
+            cmd.append("--vlm-use-freeform-first")
+        if args.vlm_enable_thinking:
+            cmd.append("--vlm-enable-thinking")
+        started = datetime.now(timezone.utc).isoformat()
+        result = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)
+        logs_dir = round_dir / "loop_logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "stdout.log").write_text(result.stdout or "", encoding="utf-8")
+        (logs_dir / "stderr.log").write_text(result.stderr or "", encoding="utf-8")
+
+        row = {}
+        if (round_dir / "manifest.jsonl").exists():
+            rows = read_jsonl(round_dir / "manifest.jsonl")
+            row = rows[0] if rows else {}
+        review = compact_review(row)
+        prev_review = history[-1]["review"] if history else None
+        improvement = constraint_improvement(prev_review, review) if prev_review else {}
+        event = {
+            "round_idx": round_idx,
+            "started_at": started,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "original_prompt": original_prompt,
+            "rewritten_prompt": prompt,
+            "prompt": prompt,
+            "rewrite_reason": rewrite_reason,
+            "failed_constraints": review.get("failed_constraints", []),
+            "uncertain_constraints": review.get("uncertain_constraints", []),
+            "passed_constraints": review.get("passed_constraints", []),
+            "image_path": row.get("output_path"),
+            "review_json": review.get("review_path"),
+            "constraint_improvement_from_prev": improvement,
+            "round_dir": str(round_dir),
+            "returncode": result.returncode,
+            "review": review,
+        }
+        history.append(event)
+        if best_event is None or review_rank(review) > review_rank(best_event["review"]):
+            best_event = event
+        success, success_evidence = has_failure_then_improvement(history)
+        state = {
+            "status": "running",
+            "success_criterion": "failure_then_constraint_improvement"
+            if args.require_fail_then_improve
+            else "one_round_pass_allowed",
+            "success_evidence": success_evidence,
+            "prompt_meta": prompt_meta,
+            "history": history,
+            "best": best_event,
+        }
+        write_json(output_root / "loop_state.json", state)
+
+        if result.returncode != 0:
+            write_json(output_root / "loop_state.json", {"status": "failed", "history": history, "best": best_event})
+            raise SystemExit(result.returncode)
+        visual_pass = review.get("validation_status") == "pass"
+        if args.require_fail_then_improve and success:
+            write_json(
+                output_root / "loop_state.json",
+                {
+                    **state,
+                    "status": "improved_after_failure",
+                    "success_evidence": success_evidence,
+                    "history": history,
+                    "best": best_event,
+                },
+            )
+            return
+        if (
+            not args.require_fail_then_improve
+            and args.stop_on_pass
+            and visual_pass
+            and review.get("vlm_route") == "pass"
+        ):
+            write_json(
+                output_root / "loop_state.json",
+                {
+                    **state,
+                    "status": "passed",
+                    "history": history,
+                    "best": best_event,
+                },
+            )
+            return
+        prompt, rewrite_reason = build_rewrite(original_prompt, review, round_idx + 1)
+
+    ever_failed = any((event.get("failed_constraints") or event.get("uncertain_constraints")) for event in history)
+    status = "max_rounds_reached" if ever_failed else "no_failure_observed"
+    success, success_evidence = has_failure_then_improvement(history)
+    if success:
+        status = "improved_after_failure"
+    write_json(
+        output_root / "loop_state.json",
+        {
+            "status": status,
+            "success_criterion": "failure_then_constraint_improvement"
+            if args.require_fail_then_improve
+            else "one_round_pass_allowed",
+            "success_evidence": success_evidence,
+            "prompt_meta": prompt_meta,
+            "history": history,
+            "best": best_event,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_multimodal_t2v_cloud.sh
+++ b/scripts/run_multimodal_t2v_cloud.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-/home/jiazhuangzhuang/miniconda3/envs/aris/bin/python}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-${ROOT}/_tmp/multimodal_t2v_loop_cloud}"
+DEVICE="${DEVICE:-cuda:0}"
+MODEL_PATH="${WAN_T2V_MODEL_PATH:-/data/jiazhuangzhuang/Wan2.1-T2V-1.3B-Diffusers}"
+VLM_MODEL_PATH="${VLM_MODEL_PATH:-/huggingface/model_hub/Qwen3.6-27B}"
+USER_REQUEST="${USER_REQUEST:-A ceramic mug slowly rotates on a wooden workbench under warm lamp light}"
+MAX_ROUNDS="${MAX_ROUNDS:-5}"
+HEIGHT="${HEIGHT:-480}"
+WIDTH="${WIDTH:-832}"
+NUM_FRAMES="${NUM_FRAMES:-33}"
+FPS="${FPS:-16}"
+STEPS="${STEPS:-20}"
+GUIDANCE_SCALE="${GUIDANCE_SCALE:-5.0}"
+SEED="${SEED:-2026}"
+DRY_RUN="${DRY_RUN:-0}"
+VLM_EVAL="${VLM_EVAL:-1}"
+
+cmd=(
+  "$PYTHON_BIN" "$ROOT/scripts/run_multimodal_t2v_vlm_loop.py"
+  --output-root "$OUTPUT_ROOT"
+  --initial-request "$USER_REQUEST"
+  --max-rounds "$MAX_ROUNDS"
+  --python "$PYTHON_BIN"
+  --device "$DEVICE"
+  --generator wan-t2v
+  --model-path "$MODEL_PATH"
+  --vlm-model-path "$VLM_MODEL_PATH"
+  --height "$HEIGHT"
+  --width "$WIDTH"
+  --num-frames "$NUM_FRAMES"
+  --fps "$FPS"
+  --steps "$STEPS"
+  --guidance-scale "$GUIDANCE_SCALE"
+  --seed "$SEED"
+)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  cmd+=(--dry-run)
+fi
+if [[ "$VLM_EVAL" == "0" ]]; then
+  cmd+=(--no-vlm-eval)
+fi
+
+echo "[run_multimodal_t2v_cloud] ${cmd[*]}"
+"${cmd[@]}"

--- a/scripts/run_multimodal_t2v_vlm_loop.py
+++ b/scripts/run_multimodal_t2v_vlm_loop.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pipeline.multimodal.t2i_constraints import constraints_for_prompt
+
+
+DEFAULT_PYTHON = "/home/jiazhuangzhuang/miniconda3/envs/aris/bin/python"
+DEFAULT_MODEL = "/data/jiazhuangzhuang/Wan2.1-T2V-1.3B-Diffusers"
+DEFAULT_VLM_MODEL = "/huggingface/model_hub/Qwen3.6-27B"
+DEFAULT_NEGATIVE_PROMPT = (
+    "text, subtitles, logos, watermark, flicker, jitter, distorted anatomy, "
+    "warped geometry, impossible physics, abrupt scene cuts, low quality"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run a T2V -> keyframe VLM review prompt refinement loop")
+    p.add_argument("--output-root", required=True)
+    p.add_argument("--initial-request", required=True)
+    p.add_argument("--max-rounds", type=int, default=5)
+    p.add_argument("--python", default=DEFAULT_PYTHON)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--dry-run", action="store_true", help="Use the local GIF dry-run generator")
+    p.add_argument("--generator", default="wan-t2v")
+    p.add_argument("--model-path", default=DEFAULT_MODEL)
+    p.add_argument("--vlm-model-path", default=DEFAULT_VLM_MODEL)
+    p.add_argument("--height", type=int, default=480)
+    p.add_argument("--width", type=int, default=832)
+    p.add_argument("--num-frames", type=int, default=33)
+    p.add_argument("--fps", type=int, default=16)
+    p.add_argument("--steps", type=int, default=20)
+    p.add_argument("--guidance-scale", type=float, default=5.0)
+    p.add_argument("--seed", type=int, default=2026)
+    p.add_argument("--sample-prefix", default="t2vloop")
+    p.add_argument("--negative-prompt", default=DEFAULT_NEGATIVE_PROMPT)
+    p.add_argument("--vlm-eval", dest="vlm_eval", action="store_true", default=True)
+    p.add_argument("--no-vlm-eval", dest="vlm_eval", action="store_false")
+    p.add_argument("--vlm-max-retries", type=int, default=2)
+    p.add_argument("--vlm-enable-thinking", action="store_true")
+    p.add_argument("--stop-on-pass", action="store_true", default=True)
+    p.add_argument("--no-stop-on-pass", dest="stop_on_pass", action="store_false")
+    return p.parse_args()
+
+
+def read_jsonl(path: Path) -> List[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _rel(value: object, base: Path) -> str:
+    if not value:
+        return ""
+    path = Path(str(value))
+    if not path.is_absolute():
+        return str(path)
+    try:
+        return str(path.resolve().relative_to(base.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def build_initial_prompt(user_request: str) -> str:
+    return (
+        "Create a short, coherent text-to-video dataset sample for this request: "
+        f"{user_request.strip()} "
+        "Use one continuous scene with a clear beginning, middle, and end. Keep subject identity, camera viewpoint, "
+        "lighting, and scene layout consistent across frames. Motion should be physically plausible and easy to inspect. "
+        "Avoid text, subtitles, logos, watermarks, heavy blur, flicker, warped geometry, and abrupt scene cuts."
+    )
+
+
+def _checklist_rows(review: Dict[str, object], statuses: set[str]) -> List[dict]:
+    rows = review.get("video_checklist") or review.get("constraint_checklist") or []
+    return [
+        row
+        for row in rows
+        if isinstance(row, dict) and str(row.get("status")) in statuses
+    ]
+
+
+def refine_prompt(original_request: str, review: Dict[str, object] | None, round_idx: int) -> Tuple[str, str]:
+    if not review:
+        return build_initial_prompt(original_request), "initial_video_prompt"
+
+    issue_tags = [str(item) for item in (review.get("issue_tags") or []) if item]
+    validation_issues = [str(item) for item in (review.get("validation_issues") or []) if item]
+    suggestions = [str(item) for item in (review.get("rewrite_suggestions") or []) if item]
+    repair_rows = _checklist_rows(review, {"fail", "uncertain"})
+    pass_rows = _checklist_rows(review, {"pass"})
+
+    prompt_parts = [
+        "Regenerate a short text-to-video dataset sample for this original request:",
+        original_request.strip(),
+        f"This is revision {round_idx}; repair the previous round while preserving the intended scene and action.",
+        "Use a single continuous scene, stable camera behavior, coherent lighting, consistent subject identity, and plausible motion.",
+        "Make the main action readable in the keyframes and avoid abrupt scene changes.",
+        "Avoid text, subtitles, logos, watermarks, flicker, jitter, warped geometry, impossible physics, and unusable blur.",
+    ]
+    if repair_rows:
+        prompt_parts.append("Repair these failed or uncertain checks:")
+        prompt_parts.extend(
+            f"{row.get('constraint_id')}: {row.get('description')} (previous status={row.get('status')})"
+            for row in repair_rows[:12]
+        )
+    if suggestions:
+        prompt_parts.append("Use these reviewer suggestions:")
+        prompt_parts.extend(suggestions[:6])
+    if issue_tags or validation_issues:
+        prompt_parts.append(
+            "Previous issue tags: "
+            + ", ".join((issue_tags + validation_issues)[:12])
+            + "."
+        )
+    if pass_rows:
+        prompt_parts.append("Preserve these checks that already passed:")
+        prompt_parts.extend(
+            f"{row.get('constraint_id')}: {row.get('description')}"
+            for row in pass_rows[:8]
+            if row.get("constraint_id") and row.get("description")
+        )
+    reason_ids = [
+        str(row.get("constraint_id"))
+        for row in repair_rows
+        if row.get("constraint_id")
+    ]
+    reason = "repair_video_constraints: " + ", ".join(reason_ids[:12]) if reason_ids else "generic_video_quality_rewrite"
+    return " ".join(prompt_parts), reason
+
+
+def compact_review(row: dict) -> dict:
+    review = row.get("vlm_review") or {}
+    validation = row.get("validation") or {}
+    return {
+        "vlm_status": review.get("status"),
+        "vlm_route": review.get("vlm_route"),
+        "scores": review.get("scores", {}),
+        "issue_tags": review.get("issue_tags", []),
+        "video_checklist": review.get("video_checklist", []),
+        "video_status_counts": review.get("video_status_counts", {}),
+        "video_pass_rate": review.get("video_pass_rate"),
+        "failed_video_constraints": review.get("failed_video_constraints", []),
+        "uncertain_video_constraints": review.get("uncertain_video_constraints", []),
+        "passed_video_constraints": review.get("passed_video_constraints", []),
+        "rewrite_suggestions": review.get("rewrite_suggestions", []),
+        "validation_status": validation.get("status"),
+        "validation_issues": validation.get("issues", []),
+        "width": validation.get("width"),
+        "height": validation.get("height"),
+        "num_frames": validation.get("num_frames"),
+        "container": validation.get("container"),
+        "file_size": validation.get("file_size"),
+        "output_path": row.get("output_path"),
+        "review_path": review.get("review_path"),
+        "contact_sheet_path": review.get("contact_sheet_path"),
+        "keyframe_paths": review.get("keyframe_paths", []),
+    }
+
+
+def review_rank(review: Dict[str, object]) -> Tuple[int, int, float, int]:
+    route_score = {"pass": 3, "needs_fix": 2, "reject": 1}.get(str(review.get("vlm_route")), 0)
+    validation_score = 1 if review.get("validation_status") == "pass" else 0
+    pass_rate = review.get("video_pass_rate")
+    if isinstance(pass_rate, (int, float)):
+        fail_count = int((review.get("video_status_counts") or {}).get("fail", 0))
+        return route_score, validation_score, float(pass_rate) * 100.0, -fail_count
+    frame_count = int(review.get("num_frames") or 0)
+    return route_score, validation_score, 0.0, frame_count
+
+
+def _is_pass(review: Dict[str, object]) -> bool:
+    if review.get("validation_status") != "pass":
+        return False
+    if review.get("vlm_status") in {None, "pending", "skipped"}:
+        return False
+    return review.get("vlm_route") == "pass"
+
+
+def write_reports(output_root: Path, state: dict) -> None:
+    history = state.get("history") or []
+    md_lines = [
+        "# DataEvolver T2V VLM Loop Report",
+        "",
+        f"- Status: `{state.get('status')}`",
+        f"- Initial request: {state.get('initial_request')}",
+        f"- Max rounds: {state.get('max_rounds')}",
+        f"- Generated at: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Rounds",
+        "",
+    ]
+    for event in history:
+        review = event.get("review") or {}
+        md_lines.extend(
+            [
+                f"### Round {event.get('round_idx')}",
+                "",
+                f"- Return code: `{event.get('returncode')}`",
+                f"- Rewrite reason: `{event.get('rewrite_reason')}`",
+                f"- Video: `{event.get('video_path')}`",
+                f"- Contact sheet: `{review.get('contact_sheet_path') or ''}`",
+                f"- VLM route: `{review.get('vlm_route')}`",
+                f"- Video pass rate: `{review.get('video_pass_rate')}`",
+                f"- Failed constraints: `{review.get('failed_video_constraints')}`",
+                f"- Uncertain constraints: `{review.get('uncertain_video_constraints')}`",
+                "",
+                "Prompt:",
+                "",
+                "```text",
+                str(event.get("prompt") or ""),
+                "```",
+                "",
+            ]
+        )
+    (output_root / "T2V_LOOP_REPORT.md").write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+
+    cards = []
+    for event in history:
+        review = event.get("review") or {}
+        round_dir = Path(str(event.get("round_dir")))
+        video_src = _rel((round_dir / str(event.get("video_path"))).resolve(), output_root.resolve()) if event.get("video_path") else ""
+        sheet_src = _rel((round_dir / str(review.get("contact_sheet_path"))).resolve(), output_root.resolve()) if review.get("contact_sheet_path") else ""
+        cards.append(
+            f"""
+            <section class="round">
+              <div class="round-head">
+                <h2>Round {html.escape(str(event.get('round_idx')))}</h2>
+                <span>{html.escape(str(review.get('vlm_route')))}</span>
+              </div>
+              <video controls src="{html.escape(video_src)}"></video>
+              {'<img src="' + html.escape(sheet_src) + '" alt="keyframe contact sheet">' if sheet_src else ''}
+              <dl>
+                <dt>Rewrite</dt><dd>{html.escape(str(event.get('rewrite_reason')))}</dd>
+                <dt>Validation</dt><dd>{html.escape(str(review.get('validation_status')))} {html.escape(str(review.get('validation_issues') or []))}</dd>
+                <dt>Pass rate</dt><dd>{html.escape(str(review.get('video_pass_rate')))}</dd>
+                <dt>Failed</dt><dd>{html.escape(str(review.get('failed_video_constraints') or []))}</dd>
+                <dt>Uncertain</dt><dd>{html.escape(str(review.get('uncertain_video_constraints') or []))}</dd>
+              </dl>
+              <details><summary>Prompt</summary><pre>{html.escape(str(event.get('prompt') or ''))}</pre></details>
+            </section>
+            """
+        )
+    html_doc = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DataEvolver T2V Loop Report</title>
+  <style>
+    body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1e2428; background: #f6f7f8; }}
+    header {{ padding: 28px 36px 20px; background: #111820; color: white; }}
+    header h1 {{ margin: 0 0 8px; font-size: 26px; letter-spacing: 0; }}
+    header p {{ margin: 4px 0; max-width: 980px; color: #d7dde2; }}
+    main {{ max-width: 1180px; margin: 0 auto; padding: 24px; }}
+    .round {{ background: white; border: 1px solid #d7dde2; border-radius: 8px; padding: 18px; margin-bottom: 20px; }}
+    .round-head {{ display: flex; justify-content: space-between; gap: 16px; align-items: center; }}
+    .round-head h2 {{ margin: 0 0 12px; font-size: 20px; }}
+    .round-head span {{ padding: 4px 8px; border: 1px solid #b9c2ca; border-radius: 999px; font-size: 13px; }}
+    video, img {{ display: block; width: 100%; max-height: 520px; object-fit: contain; background: #101418; border-radius: 6px; margin: 10px 0 14px; }}
+    dl {{ display: grid; grid-template-columns: 140px 1fr; gap: 8px 14px; margin: 0; }}
+    dt {{ font-weight: 700; color: #4a545d; }}
+    dd {{ margin: 0; overflow-wrap: anywhere; }}
+    details {{ margin-top: 14px; }}
+    pre {{ white-space: pre-wrap; overflow-wrap: anywhere; background: #f0f2f4; padding: 12px; border-radius: 6px; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>DataEvolver T2V Loop Report</h1>
+    <p>Status: {html.escape(str(state.get('status')))}</p>
+    <p>Initial request: {html.escape(str(state.get('initial_request')))}</p>
+  </header>
+  <main>
+    {''.join(cards)}
+  </main>
+</body>
+</html>
+"""
+    (output_root / "T2V_LOOP_REPORT.html").write_text(html_doc, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    entrypoint = REPO_ROOT / "pipeline" / "multimodal" / "run_multimodal_dataset.py"
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    original_prompt = args.initial_request
+    constraints = constraints_for_prompt(original_prompt)
+    prompt, rewrite_reason = refine_prompt(original_prompt, None, 0)
+    history = []
+    best_event = None
+
+    for round_idx in range(args.max_rounds):
+        round_dir = output_root / f"round_{round_idx:02d}"
+        sample_id = f"{args.sample_prefix}{round_idx:02d}_0001"
+        prompt_file = round_dir / "model_inputs" / "loop_prompt.json"
+        write_json(
+            prompt_file,
+            [
+                {
+                    "id": sample_id,
+                    "prompt": prompt,
+                    "original_prompt": original_prompt,
+                    "rewritten_prompt": prompt,
+                    "constraints": constraints,
+                    "rewrite_reason": rewrite_reason,
+                    "negative_prompt": args.negative_prompt,
+                }
+            ],
+        )
+
+        generator = "dryrun" if args.dry_run else args.generator
+        cmd = [
+            args.python,
+            str(entrypoint),
+            "--route",
+            "t2v",
+            "--user-request",
+            original_prompt,
+            "--output-root",
+            str(round_dir),
+            "--generator",
+            generator,
+            "--prompt-file",
+            str(prompt_file),
+            "--device",
+            args.device,
+            "--height",
+            str(args.height),
+            "--width",
+            str(args.width),
+            "--num-frames",
+            str(args.num_frames),
+            "--fps",
+            str(args.fps),
+            "--steps",
+            str(args.steps),
+            "--guidance-scale",
+            str(args.guidance_scale),
+            "--negative-prompt",
+            args.negative_prompt,
+            "--num-samples",
+            "1",
+            "--seed",
+            str(args.seed + round_idx),
+            "--sample-prefix",
+            f"{args.sample_prefix}{round_idx:02d}",
+            "--no-skip-existing",
+        ]
+        if args.dry_run:
+            cmd.append("--dry-run")
+        else:
+            cmd.extend(["--allow-model-inference", "--model-path", args.model_path])
+        if args.vlm_eval:
+            cmd.extend(
+                [
+                    "--vlm-eval",
+                    "--vlm-device",
+                    args.device,
+                    "--vlm-model-path",
+                    args.vlm_model_path,
+                    "--vlm-max-samples",
+                    "1",
+                    "--vlm-max-retries",
+                    str(args.vlm_max_retries),
+                ]
+            )
+            if args.vlm_enable_thinking:
+                cmd.append("--vlm-enable-thinking")
+
+        started = datetime.now(timezone.utc).isoformat()
+        result = subprocess.run(cmd, cwd=REPO_ROOT, text=True, capture_output=True)
+        logs_dir = round_dir / "loop_logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "stdout.log").write_text(result.stdout or "", encoding="utf-8")
+        (logs_dir / "stderr.log").write_text(result.stderr or "", encoding="utf-8")
+        (logs_dir / "command.json").write_text(json.dumps(cmd, indent=2) + "\n", encoding="utf-8")
+
+        row = {}
+        if (round_dir / "manifest.jsonl").exists():
+            rows = read_jsonl(round_dir / "manifest.jsonl")
+            row = rows[0] if rows else {}
+        review = compact_review(row)
+        event = {
+            "round_idx": round_idx,
+            "started_at": started,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "original_prompt": original_prompt,
+            "prompt": prompt,
+            "rewrite_reason": rewrite_reason,
+            "video_path": row.get("output_path"),
+            "review_json": review.get("review_path"),
+            "round_dir": str(round_dir),
+            "returncode": result.returncode,
+            "review": review,
+        }
+        history.append(event)
+        if best_event is None or review_rank(review) > review_rank(best_event["review"]):
+            best_event = event
+
+        state = {
+            "status": "running",
+            "initial_request": original_prompt,
+            "max_rounds": args.max_rounds,
+            "history": history,
+            "best": best_event,
+        }
+        write_json(output_root / "loop_state.json", state)
+        write_reports(output_root, state)
+
+        if result.returncode != 0:
+            state["status"] = "failed"
+            write_json(output_root / "loop_state.json", state)
+            write_reports(output_root, state)
+            raise SystemExit(result.returncode)
+        if args.stop_on_pass and _is_pass(review):
+            state["status"] = "passed"
+            write_json(output_root / "loop_state.json", state)
+            write_reports(output_root, state)
+            return
+        prompt, rewrite_reason = refine_prompt(original_prompt, review, round_idx + 1)
+
+    state = {
+        "status": "max_rounds_reached",
+        "initial_request": original_prompt,
+        "max_rounds": args.max_rounds,
+        "history": history,
+        "best": best_event,
+    }
+    write_json(output_root / "loop_state.json", state)
+    write_reports(output_root, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_edit_review.py
+++ b/tests/test_edit_review.py
@@ -1,0 +1,44 @@
+from pipeline.multimodal.edit_review import normalize_edit_review, default_edit_constraints
+
+
+def test_edit_review_pass_requires_all_constraints_pass():
+    constraints = default_edit_constraints("Change the blue mug to red.")
+    review = normalize_edit_review(
+        {
+            "edit_checklist": [
+                {
+                    "constraint_id": row["constraint_id"],
+                    "type": row["type"],
+                    "description": row["description"],
+                    "status": "pass",
+                    "evidence": "visible",
+                    "confidence": "high",
+                }
+                for row in constraints
+            ]
+        },
+        constraints,
+    )
+    assert review["vlm_route"] == "pass"
+    assert review["edit_status_counts"] == {"pass": 6, "fail": 0, "uncertain": 0, "total": 6}
+    assert review["issue_tags"] == ["none"]
+
+
+def test_edit_review_missing_items_are_uncertain_not_passed():
+    constraints = default_edit_constraints("Change the blue mug to red.")
+    review = normalize_edit_review(
+        {
+            "edit_checklist": [
+                {
+                    "constraint_id": "c_instruction_following",
+                    "type": "instruction_following",
+                    "description": constraints[0]["description"],
+                    "status": "pass",
+                }
+            ]
+        },
+        constraints,
+    )
+    assert review["vlm_route"] == "needs_fix"
+    assert review["edit_status_counts"] == {"pass": 1, "fail": 0, "uncertain": 5, "total": 6}
+    assert "c_source_preservation" in review["uncertain_edit_constraints"]

--- a/tests/test_multimodal_dryrun.py
+++ b/tests/test_multimodal_dryrun.py
@@ -1,0 +1,161 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = ROOT / "pipeline" / "multimodal" / "run_multimodal_dataset.py"
+
+
+def read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_t2i_dryrun_creates_manifest_and_placeholder_png(tmp_path):
+    out = tmp_path / "t2i"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ENTRYPOINT),
+            "--route",
+            "t2i",
+            "--user-request",
+            "generate desk objects",
+            "--output-root",
+            str(out),
+            "--dry-run",
+            "--num-samples",
+            "2",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    summary = json.loads((out / "dataset_summary.json").read_text(encoding="utf-8"))
+    rows = read_jsonl(out / "manifest.jsonl")
+    assert summary["route"] == "t2i"
+    assert summary["dry_run"] is True
+    assert summary["sample_count"] == 2
+    assert len(rows) == 2
+    first_output = out / rows[0]["output_path"]
+    assert first_output.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert rows[0]["metadata"]["intended_model"] == "qwen-image-2512"
+    assert rows[0]["metadata"]["intended_model_path"].endswith("Qwen-Image-2512")
+    assert rows[0]["validation"]["status"] in {"pass", "warn"}
+    assert rows[0]["vlm_review"]["status"] == "pending"
+
+
+def test_edit_dryrun_copies_input_images_and_records_instruction(tmp_path):
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    source = input_dir / "source.jpg"
+    source.write_bytes(b"fake-jpeg-for-dryrun")
+
+    out = tmp_path / "edit"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ENTRYPOINT),
+            "--route",
+            "edit",
+            "--user-request",
+            "make the main object red",
+            "--input-image-dir",
+            str(input_dir),
+            "--output-root",
+            str(out),
+            "--dry-run",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    rows = read_jsonl(out / "manifest.jsonl")
+    assert len(rows) == 1
+    copied = out / rows[0]["output_path"]
+    assert copied.read_bytes() == source.read_bytes()
+    assert rows[0]["edit_instruction"]
+    assert rows[0]["metadata"]["intended_model"] == "qwen-image-edit-2511"
+    assert rows[0]["metadata"]["intended_model_path"].endswith("Qwen-Image-Edit-2511")
+    assert rows[0]["validation"]["status"] in {"fail", "warn", "pass"}
+
+
+def test_t2v_dryrun_creates_placeholder_gif_video(tmp_path):
+    out = tmp_path / "t2v"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ENTRYPOINT),
+            "--route",
+            "t2v",
+            "--user-request",
+            "generate a short product video",
+            "--output-root",
+            str(out),
+            "--dry-run",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    rows = read_jsonl(out / "manifest.jsonl")
+    assert rows[0]["status"] == "generated"
+    assert rows[0]["output_path"].endswith(".gif")
+    assert (out / rows[0]["output_path"]).read_bytes().startswith(b"GIF")
+    assert rows[0]["metadata"]["backend"] == "placeholder_gif_video"
+    assert rows[0]["metadata"]["intended_model"] == "wan2.1-t2v-1.3b"
+    assert rows[0]["validation"]["status"] == "pass"
+
+
+def test_real_adapter_requires_explicit_inference_flag(tmp_path):
+    out = tmp_path / "blocked"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ENTRYPOINT),
+            "--route",
+            "t2i",
+            "--user-request",
+            "generate desk objects",
+            "--output-root",
+            str(out),
+            "--generator",
+            "qwen-image",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert "--allow-model-inference" in (result.stderr + result.stdout)
+
+
+def test_prompt_file_and_resume_skip_existing(tmp_path):
+    prompts = tmp_path / "prompts.txt"
+    prompts.write_text("red cube on white background\nblue mug on wood table\n", encoding="utf-8")
+    out = tmp_path / "t2i_prompts"
+    cmd = [
+        sys.executable,
+        str(ENTRYPOINT),
+        "--route",
+        "t2i",
+        "--user-request",
+        "fallback request",
+        "--prompt-file",
+        str(prompts),
+        "--output-root",
+        str(out),
+        "--dry-run",
+        "--num-samples",
+        "2",
+    ]
+    subprocess.run(cmd, cwd=ROOT, check=True)
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+    rows = read_jsonl(out / "manifest.jsonl")
+    assert len(rows) == 2
+    assert rows[0]["prompt"] == "red cube on white background"
+    assert rows[0]["status"] == "skipped_existing"
+    summary = json.loads((out / "dataset_summary.json").read_text(encoding="utf-8"))
+    assert summary["status_counts"]["skipped_existing"] == 2

--- a/tests/test_t2i_constraints.py
+++ b/tests/test_t2i_constraints.py
@@ -1,0 +1,95 @@
+from pipeline.multimodal.t2i_constraints import (
+    constraint_improvement,
+    get_prompt_bank,
+    has_failure_then_improvement,
+    normalize_constraint_review,
+    prompt_bank_counts,
+    select_prompt_specs,
+)
+
+
+def test_prompt_bank_has_required_three_tiers():
+    counts = prompt_bank_counts()
+    assert counts == {
+        "simple_object": 10,
+        "compositional_relation": 20,
+        "hard_constraints": 20,
+    }
+    assert len(get_prompt_bank()) == 50
+
+
+def test_hard_prompts_cover_checkable_constraint_types():
+    required = {
+        "count",
+        "spatial_lr",
+        "spatial_depth",
+        "occlusion",
+        "material",
+        "text_ban",
+        "transparent_reflective",
+        "part_detail",
+        "same_color_distractor",
+    }
+    for spec in select_prompt_specs(tier="hard_constraints"):
+        kinds = {row["type"] for row in spec["constraints"]}
+        assert required <= kinds
+
+
+def test_constraint_review_normalization_fails_missing_items_as_uncertain():
+    constraints = [
+        {"constraint_id": "c_count", "type": "count", "description": "Exactly three bottles."},
+        {"constraint_id": "c_no_text", "type": "text_ban", "description": "No text."},
+    ]
+    review = normalize_constraint_review(
+        {
+            "constraint_checklist": [
+                {
+                    "constraint_id": "c_count",
+                    "type": "count",
+                    "description": "Exactly three bottles.",
+                    "status": "fail",
+                    "evidence": "Only two are visible.",
+                    "confidence": "high",
+                }
+            ]
+        },
+        constraints,
+    )
+    assert review["failed_constraints"] == ["c_count"]
+    assert review["uncertain_constraints"] == ["c_no_text"]
+    assert review["vlm_route"] == "needs_fix"
+    assert review["constraint_status_counts"] == {"pass": 0, "fail": 1, "uncertain": 1, "total": 2}
+
+
+def test_failure_then_improvement_requires_specific_constraint_repair():
+    round0 = normalize_constraint_review(
+        {
+            "constraint_checklist": [
+                {"constraint_id": "c_count", "type": "count", "description": "Exactly three.", "status": "fail"},
+                {"constraint_id": "c_no_text", "type": "text_ban", "description": "No text.", "status": "pass"},
+            ]
+        },
+        [
+            {"constraint_id": "c_count", "type": "count", "description": "Exactly three."},
+            {"constraint_id": "c_no_text", "type": "text_ban", "description": "No text."},
+        ],
+    )
+    round1 = normalize_constraint_review(
+        {
+            "constraint_checklist": [
+                {"constraint_id": "c_count", "type": "count", "description": "Exactly three.", "status": "pass"},
+                {"constraint_id": "c_no_text", "type": "text_ban", "description": "No text.", "status": "pass"},
+            ]
+        },
+        [
+            {"constraint_id": "c_count", "type": "count", "description": "Exactly three."},
+            {"constraint_id": "c_no_text", "type": "text_ban", "description": "No text."},
+        ],
+    )
+    improvement = constraint_improvement(round0, round1)
+    assert improvement["has_improvement"] is True
+    assert "c_count" in improvement["improved_constraints"]
+    ok, evidence = has_failure_then_improvement([{"review": round0}, {"review": round1}])
+    assert ok is True
+    assert evidence["from_round"] == 0
+    assert evidence["to_round"] == 1


### PR DESCRIPTION
## Summary
- add a unified multimodal dataset route for T2I, image edit, Blender handoff, and T2V
- add dry-run generation plus real adapters for Qwen Image, Qwen Image Edit, and Wan2.1 T2V
- add VLM review paths, constraint-based prompt repair loops, and cloud helper scripts
- add focused tests for dry-run generation, edit review, and T2I constraint handling

## Validation
- /opt/miniconda3/bin/python3 -m compileall -q pipeline/multimodal scripts/run_multimodal_t2i_vlm_loop.py scripts/run_multimodal_t2v_vlm_loop.py tests/test_multimodal_dryrun.py tests/test_t2i_constraints.py tests/test_edit_review.py
- /opt/miniconda3/bin/python3 pipeline/multimodal/run_multimodal_dataset.py --route t2v --user-request "a red toy car slowly moves across a wooden table" --output-root _tmp/git_push_t2v_dryrun --dry-run --num-samples 1 --height 160 --width 240 --num-frames 5 --fps 8 --no-skip-existing

## Notes
Generated media outputs and local delivery packages are intentionally not included in this PR.