### PR TITLE
[codex] Add DataEvolver onboarding dry-run setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,27 +99,114 @@ The core innovation: a **goal-driven loop agent** that iteratively improves rend
 
 ## Quick Start
 
+Start with the lightweight onboarding dry-run. It checks the shape of your
+environment, prints the setup and model download plan, and writes local
+non-sensitive config files. It does **not** install dependencies, download model
+weights, write tokens, or launch GPU jobs.
+
+### 1. Clone the repository
+
 ```bash
-# Clone the repo
 git clone https://github.com/PRIS-CV/DataEvolver.git
 cd DataEvolver
+```
 
-# Configure model paths in each pipeline stage:
-#   pipeline/stage1_text_expansion.py  → Anthropic API key
-#   pipeline/stage2_t2i_generate.py    → MODEL_PATH (Qwen-Image-2512)
-#   pipeline/stage2_5_sam2_segment.py  → SAM3_CKPT
-#   pipeline/stage3_image_to_3d.py     → HUNYUAN3D_REPO, MODEL_HUB
-#   pipeline/stage5_5_vlm_review.py    → Qwen3.5-35B model path
-#   configs/scene_template.json        → blend_path, blender_binary
+### 2. Run the safe onboarding dry-run
 
+For the fastest first pass, use the `quick` profile:
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile quick \
+  --dry-run \
+  --write-local-config
+```
+
+For the default DataEvolver pipeline plan, choose a model root and run:
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile default \
+  --model-root /path/to/dataevolver-models \
+  --workspace-root "$PWD" \
+  --python-backend auto \
+  --dry-run \
+  --write-local-config
+```
+
+The script prints four sections:
+
+| Section | What it tells you |
+|---------|-------------------|
+| `preflight` | Linux, GPU, Python, `uv`/`conda`, Blender, and Hugging Face CLI availability |
+| `env plan` | The preferred `uv` environment plan and `conda` fallback |
+| `model plan` | Hugging Face repos, target paths, gated-access notes, and printed download commands |
+| `config plan` | Non-sensitive environment variables that the pipeline can read |
+
+Available profiles:
+
+| Profile | Use it when |
+|---------|-------------|
+| `quick` | You only want environment discovery and a dry-run route |
+| `default` | You want the current core pipeline plan: Qwen-Image-2512, SAM3, Hunyuan3D-2.1, DINOv2 Giant, Qwen3.5-35B-A3B, and Blender |
+| `full` | You also want the default Edit/T2V plan: Qwen-Image-Edit-2511 and Wan2.1-T2V |
+| `custom` | You already have replacement models and want them recorded for later compatibility review |
+
+When `--write-local-config` is used, the generated local files are:
+
+- `.dataevolver/local/ENVIRONMENT.md` — human-readable setup summary
+- `.dataevolver/local/env.config.json` — structured config for agents and scripts
+- `.dataevolver/local/env.sh.example` — sourceable non-sensitive path variables
+
+`.dataevolver/local/` is ignored by Git. Do not put Hugging Face, Anthropic,
+OpenAI, SSH, cookie, or API tokens in these files.
+
+If you are working with an agent environment that supports skills, ask it to use
+the `dataevolver-onboarding` skill. It should interview you for only five setup
+areas: target route, runtime location, install policy, model strategy, and
+workspace/output paths, then run the dry-run script above.
+
+### 3. Review paths and source environment overrides
+
+Before a real run, review the generated path variables:
+
+```bash
+sed -n '1,160p' .dataevolver/local/env.sh.example
+source .dataevolver/local/env.sh.example
+```
+
+The pipeline now reads these environment overrides while preserving the legacy
+fallback paths:
+
+| Variable | Used by |
+|----------|---------|
+| `QWEN_IMAGE_MODEL_PATH` | Stage 2 text-to-image model path |
+| `SAM3_CKPT`, `SAM3_DIR` | Stage 2.5 SAM3 checkpoint and package/source path |
+| `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT` | Stage 3 Hunyuan3D, paint, DINO, and RealESRGAN paths |
+| `VLM_MODEL_PATH` | Stage 5.5 VLM reviewer model path |
+
+For real Hugging Face downloads, set `HF_TOKEN` in your shell only. The dry-run
+script prints `uvx --from huggingface_hub hf download ...` commands first and
+`hf download ...` fallback commands, but v0 never executes them.
+
+### 4. Prepare scene assets and run the pipeline
+
+After dependencies, model weights, and path overrides are ready:
+
+```bash
 # Place your .blend scene file in assets/scene/
 # Place HDRI environment maps in assets/hdri/
+# Configure configs/scene_template.json for blend_path and blender_binary.
+# Set the Stage 1 LLM credential in your shell if you use text expansion.
 
-# Run the base text-to-image, 3D reconstruction, rendering, and metadata pipeline
 bash pipeline/run_all.sh
 ```
 
-The base pipeline prepares assets and render outputs. The scene-aware VLM optimization loop is launched separately through the scene-agent workflow, for example with `scripts/run_scene_agent_monitor.py` after model paths, `BLENDER_BIN`, and `configs/scene_template.json` are configured for your environment.
+The base pipeline prepares assets and render outputs. The scene-aware VLM
+optimization loop is launched separately through the scene-agent workflow, for
+example with `scripts/run_scene_agent_monitor.py` after model paths,
+`BLENDER_BIN`, and `configs/scene_template.json` are configured for your
+environment.
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -99,27 +99,109 @@ DataEvolver 将合成数据构建转化为一个 **目标驱动的优化闭环**
 
 ## 快速开始
 
+建议先从轻量 onboarding dry-run 开始。它会检查你的环境形态，打印安装、
+模型下载和配置写入计划，并在需要时生成本地非敏感配置文件。它**不会**
+安装依赖、下载模型权重、写入 token，或启动 GPU 长任务。
+
+### 1. 克隆仓库
+
 ```bash
-# 克隆仓库
 git clone https://github.com/PRIS-CV/DataEvolver.git
 cd DataEvolver
+```
 
-# 在各阶段脚本中配置模型路径：
-#   pipeline/stage1_text_expansion.py  → Anthropic API key
-#   pipeline/stage2_t2i_generate.py    → MODEL_PATH (Qwen-Image-2512)
-#   pipeline/stage2_5_sam2_segment.py  → SAM3_CKPT
-#   pipeline/stage3_image_to_3d.py     → HUNYUAN3D_REPO, MODEL_HUB
-#   pipeline/stage5_5_vlm_review.py    → Qwen3.5-35B 模型路径
-#   configs/scene_template.json        → blend_path, blender_binary
+### 2. 运行安全的 onboarding dry-run
 
+如果只是想最快了解当前环境是否可用，先使用 `quick` profile：
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile quick \
+  --dry-run \
+  --write-local-config
+```
+
+如果想生成当前默认 DataEvolver pipeline 的完整部署计划，指定模型根目录：
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile default \
+  --model-root /path/to/dataevolver-models \
+  --workspace-root "$PWD" \
+  --python-backend auto \
+  --dry-run \
+  --write-local-config
+```
+
+脚本会输出四段内容：
+
+| 段落 | 说明 |
+|------|------|
+| `preflight` | Linux、GPU、Python、`uv`/`conda`、Blender、Hugging Face CLI 可用性 |
+| `env plan` | 优先 `uv` 的环境计划，以及 `conda` fallback |
+| `model plan` | Hugging Face repo、目标路径、gated access 提示和打印出的下载命令 |
+| `config plan` | pipeline 可读取的非敏感环境变量 |
+
+可选 profile：
+
+| Profile | 适用场景 |
+|---------|----------|
+| `quick` | 只做环境探测和 dry-run 路线 |
+| `default` | 使用当前核心 pipeline：Qwen-Image-2512、SAM3、Hunyuan3D-2.1、DINOv2 Giant、Qwen3.5-35B-A3B 和 Blender |
+| `full` | 在 `default` 基础上额外覆盖 Edit/T2V 默认计划：Qwen-Image-Edit-2511 和 Wan2.1-T2V |
+| `custom` | 你已有替代模型，希望先记录下来，后续再做兼容性检查 |
+
+使用 `--write-local-config` 后，会生成：
+
+- `.dataevolver/local/ENVIRONMENT.md`：人类和 agent 可读的环境摘要
+- `.dataevolver/local/env.config.json`：结构化配置，便于 agent 和脚本读取
+- `.dataevolver/local/env.sh.example`：可 source 的非敏感路径变量示例
+
+`.dataevolver/local/` 已被 Git 忽略。不要把 Hugging Face、Anthropic、
+OpenAI、SSH、cookie 或 API token 写入这些文件。
+
+如果你在支持 skills 的 agent 环境中使用 DataEvolver，可以让 agent 使用
+`dataevolver-onboarding` skill。它应该只围绕五类信息进行访谈：目标路线、
+运行位置、安装策略、模型策略、工作/输出路径，然后运行上面的 dry-run 脚本。
+
+### 3. 检查路径并 source 环境变量
+
+真实运行前，先检查生成的路径变量：
+
+```bash
+sed -n '1,160p' .dataevolver/local/env.sh.example
+source .dataevolver/local/env.sh.example
+```
+
+pipeline 现在会优先读取这些环境变量，同时保留旧机器路径作为 fallback：
+
+| 变量 | 用途 |
+|------|------|
+| `QWEN_IMAGE_MODEL_PATH` | Stage 2 文生图模型路径 |
+| `SAM3_CKPT`, `SAM3_DIR` | Stage 2.5 SAM3 checkpoint 和源码/包路径 |
+| `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT` | Stage 3 Hunyuan3D、paint、DINO 和 RealESRGAN 路径 |
+| `VLM_MODEL_PATH` | Stage 5.5 VLM reviewer 模型路径 |
+
+真实 Hugging Face 下载时，只在 shell 中设置 `HF_TOKEN`。dry-run 脚本会优先
+打印 `uvx --from huggingface_hub hf download ...` 命令，并提供
+`hf download ...` fallback，但 v0 不会执行这些命令。
+
+### 4. 准备场景资产并运行 pipeline
+
+当依赖、模型权重和路径变量都准备好后：
+
+```bash
 # 将 .blend 场景文件放入 assets/scene/
 # 将 HDRI 环境贴图放入 assets/hdri/
+# 在 configs/scene_template.json 中配置 blend_path 和 blender_binary。
+# 如果使用文本扩展阶段，请在 shell 中设置 Stage 1 LLM 凭据。
 
-# 运行基础文生图、3D 重建、渲染和元数据流水线
 bash pipeline/run_all.sh
 ```
 
-基础流水线负责准备资产和渲染输出。场景感知 VLM 优化闭环需要在配置好模型路径、`BLENDER_BIN` 和 `configs/scene_template.json` 后，通过 scene-agent workflow 单独启动，例如使用 `scripts/run_scene_agent_monitor.py`。
+基础流水线负责准备资产和渲染输出。场景感知 VLM 优化闭环需要在配置好模型
+路径、`BLENDER_BIN` 和 `configs/scene_template.json` 后，通过 scene-agent
+workflow 单独启动，例如使用 `scripts/run_scene_agent_monitor.py`。
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a lightweight DataEvolver onboarding demo, documents the new quick-start path in both English and Chinese READMEs, and prepares the existing pipeline for configurable model paths. The onboarding flow is intentionally dry-run only: it collects the minimum setup profile, writes non-sensitive local environment artifacts when requested, and prints the install/model/config plan without downloading model weights, installing dependencies, writing tokens, or launching long jobs.

## Problem

New users currently need to understand the full model/runtime surface before they can run DataEvolver. Even after generating an onboarding profile, a real deployment path would still be blocked by legacy hard-coded model paths in Stage2, SAM3, Hunyuan3D, and VLM review. The README quick starts also pointed users at manual per-stage path edits instead of the new onboarding flow.

## Root Cause

The existing pipeline assumes the original machine layout for Qwen-Image, SAM3, Hunyuan3D, DINO/RealESRGAN, and the VLM reviewer. There was also no repository-provided lightweight skill or dry-run bootstrap script to turn a short setup interview into a reusable local environment profile.

## Fix

- Adds `.agents/skills/dataevolver-onboarding/` with a concise 5-question onboarding flow.
- Adds `scripts/bootstrap_dataevolver_default.sh`, a v0 dry-run bootstrap script for `quick`, `default`, `full`, and `custom` profiles.
- Updates `README.md` and `README_zh.md` Quick Start sections with the dry-run onboarding path, profile choices, generated local config files, token safety rules, env overrides, and the handoff into real pipeline execution.
- Writes ignored local artifacts under `.dataevolver/local/` only when `--write-local-config` is used.
- Keeps tokens out of project files; real Hugging Face downloads read `HF_TOKEN` from the shell only.
- Adds env override support while preserving legacy fallbacks:
  - `QWEN_IMAGE_MODEL_PATH`
  - `SAM3_CKPT`
  - `SAM3_DIR`
  - `HUNYUAN3D_REPO`
  - `MODEL_HUB`
  - `PAINT_MODEL_HUB`
  - `DINO_MODEL_PATH`
  - `REALESRGAN_CKPT`
  - `VLM_MODEL_PATH`

## Validation

- `python3 -m py_compile pipeline/stage2_t2i_generate.py pipeline/stage2_5_sam2_segment.py pipeline/stage3_image_to_3d.py pipeline/stage5_5_vlm_review.py`
- `bash -n scripts/bootstrap_dataevolver_default.sh`
- `python3 /mnt/c/Users/86159/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/dataevolver-onboarding`
- `bash scripts/bootstrap_dataevolver_default.sh --profile default --model-root /tmp/dataevolver-pr-push-models --workspace-root "$PWD" --dry-run --write-local-config`
- Verified generated `env.config.json` contains 9 path overrides including `REALESRGAN_CKPT`.
- Verified generated local config does not contain real tokens/passwords/cookies/private keys.
- Verified no model root was created, confirming dry-run did not download weights.
- Verified README and README_zh fenced code blocks are balanced.
- `git diff --check main..HEAD`

## Notes

`graphify update .` was attempted in the clean worktree but still fails in this environment with `zsh:1: permission denied: graphify`. This matches the existing local tool permission issue and is not introduced by this PR.

Previous PR #8 could not be reopened after it was closed, so this PR is the active replacement with the latest branch head.
