### PR TITLE
[codex] 完善生产部署与环境配置指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,47 +166,128 @@ the `dataevolver-onboarding` skill. It should interview you for only five setup
 areas: target route, runtime location, install policy, model strategy, and
 workspace/output paths, then run the dry-run script above.
 
-### 3. Review paths and source environment overrides
+### 3. Production Setup
 
-Before a real run, review the generated path variables:
-
-```bash
-sed -n '1,160p' .dataevolver/local/env.sh.example
-source .dataevolver/local/env.sh.example
-```
-
-The pipeline now reads these environment overrides while preserving the legacy
-fallback paths:
-
-| Variable | Used by |
-|----------|---------|
-| `QWEN_IMAGE_MODEL_PATH` | Stage 2 text-to-image model path |
-| `SAM3_CKPT`, `SAM3_DIR` | Stage 2.5 SAM3 checkpoint and package/source path |
-| `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT` | Stage 3 Hunyuan3D, paint, DINO, and RealESRGAN paths |
-| `VLM_MODEL_PATH` | Stage 5.5 VLM reviewer model path |
-
-For real Hugging Face downloads, set `HF_TOKEN` in your shell only. The dry-run
-script prints `uvx --from huggingface_hub hf download ...` commands first and
-`hf download ...` fallback commands, but v0 never executes them.
-
-### 4. Prepare scene assets and run the pipeline
-
-After dependencies, model weights, and path overrides are ready:
+Create the runtime environment. On shared GPU servers, prefer
+`--system-site-packages` so an already validated NVIDIA PyTorch build can be
+reused. Install the CUDA wheel only if `import torch` fails inside the venv or
+reports no usable CUDA.
 
 ```bash
-# Place your .blend scene file in assets/scene/
-# Place HDRI environment maps in assets/hdri/
-# Configure configs/scene_template.json for blend_path and blender_binary.
-# Set the Stage 1 LLM credential in your shell if you use text expansion.
+uv venv .venv --python 3.10 --system-site-packages
+source .venv/bin/activate
 
-bash pipeline/run_all.sh
+python - <<'PY'
+import torch
+print(torch.__version__, torch.cuda.is_available())
+PY
+
+# Fallback only when the torch check above fails.
+uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+
+uv pip install \
+  "numpy<2" "tokenizers==0.22.1" \
+  diffsynth transformers accelerate diffusers safetensors \
+  pillow opencv-python scipy scikit-image imageio trimesh \
+  rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan \
+  iopath timm ftfy \
+  opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 ```
 
-The base pipeline prepares assets and render outputs. The scene-aware VLM
-optimization loop is launched separately through the scene-agent workflow, for
-example with `scripts/run_scene_agent_monitor.py` after model paths,
-`BLENDER_BIN`, and `configs/scene_template.json` are configured for your
-environment.
+Review `.dataevolver/local/env.sh.example`, copy it to a machine-local file,
+then source it before every real run:
+
+```bash
+cp .dataevolver/local/env.sh.example .dataevolver/local/env.remote.sh
+# Edit paths only. Do not put tokens in this file.
+source .dataevolver/local/env.remote.sh
+source .venv/bin/activate
+```
+
+Production deployments should use environment variables instead of editing
+pipeline scripts:
+
+| Variable | Points to |
+|----------|-----------|
+| `DATAEVOLVER_WORKSPACE_ROOT` | DataEvolver checkout |
+| `QWEN_IMAGE_MODEL_PATH` | Qwen-Image-2512 weights |
+| `QWEN_IMAGE_EDIT_MODEL_PATH` | Qwen-Image-Edit-2511 weights, optional for edit routes |
+| `SAM3_CKPT` | `sam3.pt` checkpoint |
+| `SAM3_DIR` | SAM3 source checkout or importable package path |
+| `HUNYUAN3D_REPO` | Tencent-Hunyuan/Hunyuan3D-2.1 source checkout |
+| `MODEL_HUB` | Hunyuan3D-2.1 weights |
+| `PAINT_MODEL_HUB` | Hunyuan3D paint weights, usually the same as `MODEL_HUB` |
+| `DINO_MODEL_PATH` | DINOv2 Giant checkpoint directory |
+| `REALESRGAN_CKPT` | `RealESRGAN_x4plus.pth` used by Hunyuan paint |
+| `VLM_MODEL_PATH` | Qwen3.5-35B-A3B, or a verified compatible Qwen3.x replacement |
+| `BLENDER_BIN` | Blender executable |
+
+Keep source checkouts and model weights separate. `SAM3_CKPT` is the checkpoint
+file, while `SAM3_DIR` is the SAM3 code path. `HUNYUAN3D_REPO` is the
+Hunyuan3D source checkout, while `MODEL_HUB` and `PAINT_MODEL_HUB` are weight
+directories.
+
+After CUDA and `nvcc` are confirmed, build Hunyuan3D's native extensions:
+
+```bash
+uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"
+cd "$HUNYUAN3D_REPO/hy3dpaint/DifferentiableRenderer"
+bash compile_mesh_painter.sh
+```
+
+### 4. Production Smoke Tests
+
+Run preflight and import checks first:
+
+```bash
+python3 --version
+uv --version
+nvidia-smi
+df -h .
+"$BLENDER_BIN" --version
+
+python - <<'PY'
+import torch
+print("cuda:", torch.cuda.is_available(), "bf16:", torch.cuda.is_bf16_supported())
+from transformers import AutoProcessor
+from opentelemetry import trace
+PY
+```
+
+Then validate one object through the runtime stages:
+
+```bash
+SMOKE_ROOT=.dataevolver/local/smoke
+
+python pipeline/stage2_t2i_generate.py --ids obj_001 --steps 1 --height 512 --width 512 --device cuda:0
+python pipeline/stage2_5_sam2_segment.py --ids obj_001 --device cuda:0
+python pipeline/stage3_image_to_3d.py --ids obj_001 --shape-only --device cuda:0 --output-dir "$SMOKE_ROOT/meshes_shape_only"
+
+python pipeline/stage3_image_to_3d.py \
+  --no-skip \
+  --ids obj_001 \
+  --device cuda:0 \
+  --output-dir "$SMOKE_ROOT/meshes_textured" \
+  --paint-max-faces 5000 \
+  --paint-remesh-modes false \
+  --paint-attempt-timeout-sec 300
+```
+
+`--shape-only` is a fallback for missing DINO, RealESRGAN, or paint extensions;
+it is not a complete textured production-readiness check. Also run the Stage
+5.5 VLM loader smoke before starting a full review loop.
+
+After the deployment evidence has been recorded, remove generated smoke
+artifacts so the working directory stays clean:
+
+```bash
+rm -rf .dataevolver/local/smoke
+```
+
+Only after these checks pass should you prepare scene assets and run
+`bash pipeline/run_all.sh`. The scene-aware VLM optimization loop is launched
+separately through `scripts/run_scene_agent_monitor.py` after model paths,
+`BLENDER_BIN`, and `configs/scene_template.json` are configured.
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -164,44 +164,124 @@ OpenAI、SSH、cookie 或 API token 写入这些文件。
 `dataevolver-onboarding` skill。它应该只围绕五类信息进行访谈：目标路线、
 运行位置、安装策略、模型策略、工作/输出路径，然后运行上面的 dry-run 脚本。
 
-### 3. 检查路径并 source 环境变量
+### 3. Production Setup（生产部署）
 
-真实运行前，先检查生成的路径变量：
+创建运行环境。在共享 GPU 服务器上，优先使用
+`--system-site-packages` 复用已经验证过的 NVIDIA PyTorch。只有当 venv 内
+`import torch` 失败或没有可用 CUDA 时，再安装 CUDA wheel。
 
 ```bash
-sed -n '1,160p' .dataevolver/local/env.sh.example
-source .dataevolver/local/env.sh.example
+uv venv .venv --python 3.10 --system-site-packages
+source .venv/bin/activate
+
+python - <<'PY'
+import torch
+print(torch.__version__, torch.cuda.is_available())
+PY
+
+# 仅当上面的 torch 检查失败时使用该 fallback。
+uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+
+uv pip install \
+  "numpy<2" "tokenizers==0.22.1" \
+  diffsynth transformers accelerate diffusers safetensors \
+  pillow opencv-python scipy scikit-image imageio trimesh \
+  rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan \
+  iopath timm ftfy \
+  opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 ```
 
-pipeline 现在会优先读取这些环境变量，同时保留旧机器路径作为 fallback：
+检查 `.dataevolver/local/env.sh.example`，复制为机器本地配置文件，并在每次
+真实运行前 source：
 
-| 变量 | 用途 |
+```bash
+cp .dataevolver/local/env.sh.example .dataevolver/local/env.remote.sh
+# 只编辑路径，不要把 token 写入这个文件。
+source .dataevolver/local/env.remote.sh
+source .venv/bin/activate
+```
+
+生产部署应使用环境变量覆盖路径，而不是直接修改 pipeline 脚本：
+
+| 变量 | 指向 |
 |------|------|
-| `QWEN_IMAGE_MODEL_PATH` | Stage 2 文生图模型路径 |
-| `SAM3_CKPT`, `SAM3_DIR` | Stage 2.5 SAM3 checkpoint 和源码/包路径 |
-| `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT` | Stage 3 Hunyuan3D、paint、DINO 和 RealESRGAN 路径 |
-| `VLM_MODEL_PATH` | Stage 5.5 VLM reviewer 模型路径 |
+| `DATAEVOLVER_WORKSPACE_ROOT` | DataEvolver 代码目录 |
+| `QWEN_IMAGE_MODEL_PATH` | Qwen-Image-2512 权重 |
+| `QWEN_IMAGE_EDIT_MODEL_PATH` | Qwen-Image-Edit-2511 权重，编辑路线可选 |
+| `SAM3_CKPT` | `sam3.pt` checkpoint |
+| `SAM3_DIR` | SAM3 源码目录或可 import 的 package 路径 |
+| `HUNYUAN3D_REPO` | Tencent-Hunyuan/Hunyuan3D-2.1 源码 checkout |
+| `MODEL_HUB` | Hunyuan3D-2.1 权重目录 |
+| `PAINT_MODEL_HUB` | Hunyuan3D paint 权重目录，通常与 `MODEL_HUB` 相同 |
+| `DINO_MODEL_PATH` | DINOv2 Giant checkpoint 目录 |
+| `REALESRGAN_CKPT` | Hunyuan paint 使用的 `RealESRGAN_x4plus.pth` |
+| `VLM_MODEL_PATH` | Qwen3.5-35B-A3B，或验证兼容的 Qwen3.x 替代模型 |
+| `BLENDER_BIN` | Blender 可执行文件 |
 
-真实 Hugging Face 下载时，只在 shell 中设置 `HF_TOKEN`。dry-run 脚本会优先
-打印 `uvx --from huggingface_hub hf download ...` 命令，并提供
-`hf download ...` fallback，但 v0 不会执行这些命令。
+源码目录和权重目录必须分开。`SAM3_CKPT` 是 checkpoint 文件，
+`SAM3_DIR` 是 SAM3 代码路径。`HUNYUAN3D_REPO` 是 Hunyuan3D 源码
+checkout，`MODEL_HUB` 和 `PAINT_MODEL_HUB` 是权重目录。
 
-### 4. 准备场景资产并运行 pipeline
-
-当依赖、模型权重和路径变量都准备好后：
+确认 CUDA 和 `nvcc` 可用后，再编译 Hunyuan3D 原生扩展：
 
 ```bash
-# 将 .blend 场景文件放入 assets/scene/
-# 将 HDRI 环境贴图放入 assets/hdri/
-# 在 configs/scene_template.json 中配置 blend_path 和 blender_binary。
-# 如果使用文本扩展阶段，请在 shell 中设置 Stage 1 LLM 凭据。
-
-bash pipeline/run_all.sh
+uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"
+cd "$HUNYUAN3D_REPO/hy3dpaint/DifferentiableRenderer"
+bash compile_mesh_painter.sh
 ```
 
-基础流水线负责准备资产和渲染输出。场景感知 VLM 优化闭环需要在配置好模型
-路径、`BLENDER_BIN` 和 `configs/scene_template.json` 后，通过 scene-agent
-workflow 单独启动，例如使用 `scripts/run_scene_agent_monitor.py`。
+### 4. 生产 Smoke Tests
+
+先运行 preflight 和 import 检查：
+
+```bash
+python3 --version
+uv --version
+nvidia-smi
+df -h .
+"$BLENDER_BIN" --version
+
+python - <<'PY'
+import torch
+print("cuda:", torch.cuda.is_available(), "bf16:", torch.cuda.is_bf16_supported())
+from transformers import AutoProcessor
+from opentelemetry import trace
+PY
+```
+
+然后用一个物体验证运行链路：
+
+```bash
+SMOKE_ROOT=.dataevolver/local/smoke
+
+python pipeline/stage2_t2i_generate.py --ids obj_001 --steps 1 --height 512 --width 512 --device cuda:0
+python pipeline/stage2_5_sam2_segment.py --ids obj_001 --device cuda:0
+python pipeline/stage3_image_to_3d.py --ids obj_001 --shape-only --device cuda:0 --output-dir "$SMOKE_ROOT/meshes_shape_only"
+
+python pipeline/stage3_image_to_3d.py \
+  --no-skip \
+  --ids obj_001 \
+  --device cuda:0 \
+  --output-dir "$SMOKE_ROOT/meshes_textured" \
+  --paint-max-faces 5000 \
+  --paint-remesh-modes false \
+  --paint-attempt-timeout-sec 300
+```
+
+`--shape-only` 只是在 DINO、RealESRGAN 或 paint 扩展缺失时的 fallback，
+不等于完整 textured production readiness。启动完整 review loop 前，还需
+完成 Stage 5.5 VLM loader smoke。
+
+部署证据整理完成后，应删除生成的 smoke 产物，保持工作目录干净：
+
+```bash
+rm -rf .dataevolver/local/smoke
+```
+
+以上检查通过后，再准备场景资产并运行 `bash pipeline/run_all.sh`。场景感知
+VLM 优化闭环应在模型路径、`BLENDER_BIN` 和
+`configs/scene_template.json` 配置完成后，通过
+`scripts/run_scene_agent_monitor.py` 单独启动。
 
 ---
 

--- a/scripts/bootstrap_dataevolver_default.sh
+++ b/scripts/bootstrap_dataevolver_default.sh
@@ -181,17 +181,20 @@ print_env_plan() {
   if [[ "$PYTHON_BACKEND" == "uv" || "$PYTHON_BACKEND" == "auto" ]]; then
     printf 'Preferred uv plan:\n'
     printf '  cd %s\n' "$(quote "$WORKSPACE_ROOT")"
-    printf '  uv venv .venv --python 3.10\n'
+    printf '  uv venv .venv --python 3.10 --system-site-packages\n'
     printf '  source .venv/bin/activate\n'
+    printf '  python -c "import torch; print(torch.__version__, torch.cuda.is_available())"\n'
+    printf '  # Fallback only if the torch import above fails or has no usable CUDA:\n'
     printf '  uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121\n'
-    printf '  uv pip install huggingface_hub diffusers transformers accelerate pillow opencv-python numpy safetensors\n'
+    printf '  uv pip install "numpy<2" "tokenizers==0.22.1" diffsynth transformers accelerate diffusers safetensors pillow opencv-python scipy scikit-image imageio trimesh rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan iopath timm ftfy opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http\n'
   fi
   if [[ "$PYTHON_BACKEND" == "conda" || "$PYTHON_BACKEND" == "auto" ]]; then
     printf '\nConda fallback plan:\n'
     printf '  conda create -n dataevolver python=3.10 -y\n'
     printf '  conda activate dataevolver\n'
+    printf '  python -c "import torch; print(torch.__version__, torch.cuda.is_available())" || true\n'
     printf '  pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121\n'
-    printf '  pip install huggingface_hub diffusers transformers accelerate pillow opencv-python numpy safetensors\n'
+    printf '  pip install "numpy<2" "tokenizers==0.22.1" diffsynth transformers accelerate diffusers safetensors pillow opencv-python scipy scikit-image imageio trimesh rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan iopath timm ftfy opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http\n'
   fi
   printf '\nTool bootstrap plan if commands are missing (printed only):\n'
   printf '  # Install uv for the fastest Python environment path:\n'
@@ -200,9 +203,13 @@ print_env_plan() {
   printf '  uvx --from huggingface_hub hf --help || hf --help\n'
   printf '  # Optional standalone Hugging Face CLI installer:\n'
   printf '  curl -LsSf https://hf.co/cli/install.sh | bash\n'
-  printf '\nDeferred v1 work:\n'
-  printf '  Install SAM3 and Hunyuan3D repo-specific requirements after preflight.\n'
-  printf '  Compile Hunyuan3D CUDA/C++ extensions only after CUDA/nvcc compatibility is confirmed.\n'
+  printf '\nSource and native-extension plan after target-host preflight:\n'
+  printf '  # Keep source checkouts separate from weight directories.\n'
+  printf '  git clone --depth 1 https://github.com/facebookresearch/sam3.git .dataevolver/local/vendor/sam3-src\n'
+  printf '  git clone --depth 1 https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1.git .dataevolver/local/vendor/Hunyuan3D-2.1-src\n'
+  printf '  test -f "$HUNYUAN3D_REPO/requirements.txt" && uv pip install -r "$HUNYUAN3D_REPO/requirements.txt"\n'
+  printf '  uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"\n'
+  printf '  cd "$HUNYUAN3D_REPO/hy3dpaint/DifferentiableRenderer" && bash compile_mesh_painter.sh\n'
 }
 
 model_line() {
@@ -274,8 +281,10 @@ print_config_plan() {
   printf '\nNon-sensitive variables to export later:\n'
   printf '  DATAEVOLVER_MODEL_ROOT=%s\n' "$MODEL_ROOT"
   printf '  DATAEVOLVER_WORKSPACE_ROOT=%s\n' "$WORKSPACE_ROOT"
+  printf '  BLENDER_BIN=/path/to/blender\n'
   if [[ "$PROFILE" == "default" || "$PROFILE" == "full" ]]; then
     printf '  QWEN_IMAGE_MODEL_PATH=%s/Qwen-Image-2512\n' "$MODEL_ROOT"
+    printf '  QWEN_IMAGE_EDIT_MODEL_PATH=%s/Qwen-Image-Edit-2511\n' "$MODEL_ROOT"
     printf '  SAM3_CKPT=%s/sam3/sam3.pt\n' "$MODEL_ROOT"
     printf '  SAM3_DIR=<source checkout or package path for SAM3>\n'
     printf '  HUNYUAN3D_REPO=<clone path for Tencent-Hunyuan/Hunyuan3D-2.1>\n'
@@ -284,9 +293,11 @@ print_config_plan() {
     printf '  DINO_MODEL_PATH=%s/dinov2-giant\n' "$MODEL_ROOT"
     printf '  REALESRGAN_CKPT=<clone path for Tencent-Hunyuan/Hunyuan3D-2.1>/hy3dpaint/ckpt/RealESRGAN_x4plus.pth\n'
     printf '  VLM_MODEL_PATH=%s/Qwen3.5-35B-A3B\n' "$MODEL_ROOT"
+    printf '  STAGE3_PAINT_MAX_FACES=5000\n'
+    printf '  STAGE3_PAINT_REMESH_MODES=false\n'
+    printf '  STAGE3_PAINT_ATTEMPT_TIMEOUT_SEC=300\n'
   fi
   if [[ "$PROFILE" == "full" ]]; then
-    printf '  QWEN_IMAGE_EDIT_MODEL_PATH=%s/Qwen-Image-Edit-2511\n' "$MODEL_ROOT"
     printf '  WAN_T2V_MODEL_PATH=%s/Wan2.1-T2V-1.3B-Diffusers\n' "$MODEL_ROOT"
   fi
   printf '\nRuntime env overrides to source before real one-click setup:\n'
@@ -294,6 +305,7 @@ print_config_plan() {
   printf '  pipeline/stage2_5_sam2_segment.py: SAM3_CKPT/SAM3_DIR <- env overrides\n'
   printf '  pipeline/stage3_image_to_3d.py: HUNYUAN3D_REPO/MODEL_HUB/PAINT_MODEL_HUB/DINO_MODEL_PATH/REALESRGAN_CKPT <- env overrides\n'
   printf '  pipeline/stage5_5_vlm_review.py: VLM_MODEL_PATH <- env override\n'
+  printf '  scene/render scripts: BLENDER_BIN <- env override\n'
 }
 
 write_local_config() {
@@ -390,6 +402,11 @@ path_override_plan = [
         "constant": "VLM_MODEL_PATH",
         "env": "VLM_MODEL_PATH",
     },
+    {
+        "file": "scene/render scripts",
+        "constant": "BLENDER_BIN",
+        "env": "BLENDER_BIN",
+    },
 ]
 
 access_requirements = [
@@ -418,6 +435,7 @@ if tooling_status["nvidia-smi"]["status"] == "missing":
 if access_requirements:
     next_actions.append("Confirm Hugging Face access for gated/access-dependent model repos.")
 next_actions.append("Before real setup, source reviewed path overrides derived from env.sh.example.")
+next_actions.append("Run smoke tests in order: preflight, import smoke, Stage 2, Stage 2.5, Stage 3 shape-only, Stage 3 textured, Stage 5.5 VLM loader.")
 
 target_workflow = {
     "quick": "quick_demo",
@@ -453,8 +471,10 @@ payload = {
     "path_override_plan": path_override_plan,
     "v1_blockers": [
         "Source or export the path override variables before running the pipeline on a new host.",
+        "Keep SAM3 and Hunyuan3D source checkouts separate from downloaded weight directories.",
         "Install SAM3 and Hunyuan3D repo-specific dependencies after target-host preflight.",
         "Compile Hunyuan3D CUDA/C++ extensions only after CUDA/nvcc compatibility is known.",
+        "Run Stage 3 textured smoke with bounded paint settings before treating the host as production-ready.",
     ],
     "next_actions": next_actions,
     "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -490,6 +510,33 @@ override_rows = "\n".join(
 
 next_action_rows = "\n".join(f"- {item}" for item in next_actions)
 
+dependency_plan = """Use `uv venv .venv --python 3.10 --system-site-packages` first on shared GPU servers so a validated system NVIDIA PyTorch build can be reused. Install the CUDA wheel only when `import torch` fails inside the venv or reports no usable CUDA.
+
+Runtime pins from production validation:
+
+- `numpy<2`
+- `tokenizers==0.22.1`
+- SAM3 extras: `iopath`, `timm`, `ftfy`
+- Hunyuan paint/native build: `uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"` after CUDA/nvcc preflight
+- DifferentiableRenderer: compile only after CUDA/nvcc compatibility is confirmed"""
+
+path_separation = """Keep code and weights separate:
+
+- `SAM3_CKPT` points to `sam3.pt`.
+- `SAM3_DIR` points to the SAM3 source checkout or importable package.
+- `HUNYUAN3D_REPO` points to the Tencent-Hunyuan/Hunyuan3D-2.1 source checkout.
+- `MODEL_HUB` and `PAINT_MODEL_HUB` point to Hunyuan3D weight directories."""
+
+smoke_plan = """Production readiness smoke order:
+
+1. Preflight: Python, uv, GPU, disk, Blender, and model paths.
+2. Import smoke: torch CUDA/bf16, Qwen image dependencies, SAM3, Hunyuan shape/paint, transformers, and telemetry packages.
+3. Runtime smoke: Stage 2 -> Stage 2.5 -> Stage 3 shape-only -> Stage 3 textured -> Stage 5.5 VLM loader.
+4. Stage 3 textured smoke should write to a local smoke directory such as `.dataevolver/local/smoke/meshes_textured` and use bounded paint controls such as `--paint-max-faces 5000 --paint-remesh-modes false --paint-attempt-timeout-sec 300`.
+5. After the agent records the smoke evidence in the deployment note, delete generated smoke artifacts with `rm -rf .dataevolver/local/smoke` so the working directory stays clean.
+
+`--shape-only` is a fallback for missing DINO, RealESRGAN, or paint extensions; it is not a full textured production-readiness check."""
+
 (out / "ENVIRONMENT.md").write_text(
     f"""# DataEvolver Local Environment
 
@@ -520,6 +567,18 @@ Generated by `scripts/bootstrap_dataevolver_default.sh` in dry-run mode.
 
 {override_rows}
 
+## Production Dependency Plan
+
+{dependency_plan}
+
+## Source and Weight Path Separation
+
+{path_separation}
+
+## Production Smoke Tests
+
+{smoke_plan}
+
 ## Next Actions
 
 {next_action_rows}
@@ -531,6 +590,7 @@ env_lines = [
     "# Source this file after reviewing paths. It intentionally contains no tokens.",
     f"export DATAEVOLVER_WORKSPACE_ROOT={shlex.quote(workspace_root)}",
     f"export DATAEVOLVER_MODEL_ROOT={shlex.quote(model_root)}",
+    f"export BLENDER_BIN={shlex.quote(shutil.which('blender') or '/path/to/blender')}",
 ]
 for model in models:
     env_name = model.get("env")
@@ -541,10 +601,15 @@ for model in models:
         value = str(Path(value) / "sam3.pt")
     env_lines.append(f"export {env_name}={shlex.quote(value)}")
 if profile in {"default", "full"}:
+    if profile == "default":
+        env_lines.append(f"export QWEN_IMAGE_EDIT_MODEL_PATH={shlex.quote(str(Path(model_root) / 'Qwen-Image-Edit-2511'))}")
     env_lines.append(f"export PAINT_MODEL_HUB={shlex.quote(str(Path(model_root) / 'Hunyuan3D-2.1'))}")
-    env_lines.append("# export SAM3_DIR=/path/to/sam3/source-or-package")
-    env_lines.append("# export HUNYUAN3D_REPO=/path/to/Hunyuan3D-2.1/source")
-    env_lines.append("# export REALESRGAN_CKPT=/path/to/Hunyuan3D-2.1/source/hy3dpaint/ckpt/RealESRGAN_x4plus.pth")
+    env_lines.append(f"export SAM3_DIR={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/vendor/sam3-src'))}")
+    env_lines.append(f"export HUNYUAN3D_REPO={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/vendor/Hunyuan3D-2.1-src'))}")
+    env_lines.append('export REALESRGAN_CKPT="$HUNYUAN3D_REPO/hy3dpaint/ckpt/RealESRGAN_x4plus.pth"')
+    env_lines.append("export STAGE3_PAINT_MAX_FACES=5000")
+    env_lines.append("export STAGE3_PAINT_REMESH_MODES=false")
+    env_lines.append("export STAGE3_PAINT_ATTEMPT_TIMEOUT_SEC=300")
 env_lines.append("# Set HF_TOKEN in your shell only when performing real downloads.")
 (out / "env.sh.example").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
## 背景

现有部署说明偏向手动配置，源码目录、模型权重目录和运行时依赖的边界不够明确，容易在首次部署时遗漏关键依赖或直接启动完整流水线。本次更新将已验证的部署过程整理为统一的生产准备流程。

## 主要改动

- 重写中英文 README 的生产部署入口，统一采用 uv 虚拟环境和环境变量配置。
- 新增 `scripts/bootstrap_dataevolver_default.sh`，支持 dry-run、配置模板生成和默认/完整部署 profile。
- 明确 SAM3、Hunyuan3D 的源码目录与模型权重目录必须分离配置。
- 补充 NumPy、tokenizers、iopath、timm、ftfy 等已验证依赖约束。
- 增加 Hunyuan3D CUDA 扩展编译前置检查与无 build isolation 安装方式。
- 增加从基础环境到 Stage 5.5 VLM loader 的分层 smoke test 顺序。
- 为 Stage 3 textured smoke 增加面数、重拓扑模式和超时等有界参数。
- 明确 smoke test 产物在验证记录完成后需要清理，避免污染工作目录。

## 用户影响

新用户可先生成本地配置并完成 preflight，再按 Stage 2、Stage 2.5、Stage 3 和 Stage 5.5 的顺序验证部署。缺少 DINO、RealESRGAN 或 paint 扩展时，可以使用 shape-only 定位问题，但不再将其视为完整的 textured production readiness。

## 验证

- `bash -n scripts/bootstrap_dataevolver_default.sh`
- default profile dry-run
- full profile dry-run 与本地配置模板生成
- README 与生成模板中的关键环境变量一致性检查
- Git diff whitespace 检查
- 敏感信息扫描：未包含服务器账号、IP、内部绝对路径、Token、Cookie、私钥或真实凭据

## 已知说明

- `graphify update .` 在当前本地环境中因工具执行权限问题未能运行；该问题不影响文档和 bootstrap 脚本验证。
