### PR TITLE
Add HYWorld scene reconstruction section to homepage

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -382,6 +382,58 @@ em{font-style:italic;color:var(--body-strong)}
   font-size:0.8125rem;color:var(--muted);line-height:1.4;
 }
 
+/* ===== World Model Scene Reconstruction ===== */
+.worldmodel-layout{
+  display:grid;
+  grid-template-columns:minmax(0,1.05fr) minmax(300px,0.95fr);
+  gap:40px;
+  align-items:start;
+  margin-top:48px;
+}
+.worldmodel-evidence{
+  background:var(--canvas);
+  border:1px solid var(--hairline);
+  border-radius:var(--radius-lg);
+  padding:28px;
+}
+.worldmodel-evidence h3{margin-bottom:16px}
+.worldmodel-list{
+  list-style:none;
+  display:grid;
+  gap:14px;
+}
+.worldmodel-list li{
+  display:grid;
+  grid-template-columns:auto 1fr;
+  gap:12px;
+  align-items:start;
+  font-size:0.9375rem;
+  color:var(--body);
+}
+.worldmodel-list li::before{
+  content:'';
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  background:var(--primary);
+  margin-top:8px;
+}
+.worldmodel-chip-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:24px;
+}
+.worldmodel-chip{
+  border:1px solid var(--hairline);
+  background:var(--surface-soft);
+  color:var(--body-strong);
+  border-radius:var(--radius-pill);
+  padding:7px 11px;
+  font-size:0.75rem;
+  font-weight:500;
+}
+
 /* ===== Evolution Loop ===== */
 .loop-diagram{
   display:grid;grid-template-columns:1fr auto 1fr auto 1fr auto 1fr;
@@ -770,6 +822,7 @@ em{font-style:italic;color:var(--body-strong)}
   .pipeline-visual{flex-wrap:wrap;gap:12px;justify-content:center}
   .pipeline-arrow{display:none}
   .pipeline-step{min-width:130px;flex:0 0 auto}
+  .worldmodel-layout{grid-template-columns:1fr;gap:28px}
   .loop-diagram{grid-template-columns:1fr;gap:12px}
   .loop-arrow{display:none}
   .stats-grid{grid-template-columns:repeat(2,1fr)}
@@ -803,6 +856,7 @@ em{font-style:italic;color:var(--body-strong)}
     </a>
     <ul class="nav-links">
       <li><a href="#pipeline">Pipeline</a></li>
+      <li><a href="#worldmodel">3D Scenes</a></li>
       <li><a href="#evolution">VLM Loop</a></li>
       <li><a href="#dataset">Dataset</a></li>
       <li><a href="#gallery">Gallery</a></li>
@@ -962,6 +1016,55 @@ em{font-style:italic;color:var(--body-strong)}
         <div class="pipeline-step-num">5</div>
         <div class="pipeline-step-title">VLM Review Loop</div>
         <div class="pipeline-step-desc">Review → act → re-render until keep</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HYWorld World Model Scene Reconstruction -->
+<section class="section section-card" id="worldmodel">
+  <div class="section-inner">
+    <div class="section-label">World Model Reconstruction</div>
+    <h2 class="section-title">Automated 3D Scene Construction</h2>
+    <p class="section-desc">
+      DataEvolver can extend beyond object reconstruction into full scene reconstruction. The HYWorld / WorldMirror route converts a scene prompt or input image into a panorama, reconstructs metric scene geometry, validates the Blender scene contract, and produces multi-view evidence before object insertion.
+    </p>
+
+    <div class="visual-frame">
+      <div class="visual-frame-inner">
+        <img src="images/readme/3D-build.png" alt="HYWorld automated 3D scene reconstruction pipeline">
+        <div class="visual-caption">
+          <strong>HYWorld / WorldMirror scene pipeline</strong>
+          <span>Prompt or image → HY-Pano → real 3D reconstruction → scene contract → multi-view validation → final manifest.</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="worldmodel-layout">
+      <div class="card-grid">
+        <div class="card">
+          <h3 class="card-title">Panorama to Metric Scene</h3>
+          <p class="card-desc">HY-Pano creates a 360° scene context; HYWorld and WorldMirror reconstruct depth, camera priors, and scene geometry instead of relying on a fixed panorama shell.</p>
+        </div>
+        <div class="card">
+          <h3 class="card-title">Blender Scene Contract</h3>
+          <p class="card-desc">The reconstructed mesh is converted into a contract with camera alignment, support surfaces, lineage hashes, and gates that reject constant-depth pseudo-3D outputs.</p>
+        </div>
+      </div>
+      <div class="worldmodel-evidence">
+        <h3>Review Evidence</h3>
+        <ul class="worldmodel-list">
+          <li>Preserved stage artifacts and SHA-256 manifests for HY-Pano and full worldgen.</li>
+          <li>Pure-scene multi-view renders before object insertion.</li>
+          <li>Mesh-raycast support placement with scene-camera matching.</li>
+          <li>Final object-scene report with RGB, masks, depth, normals, metadata gates, and lineage.</li>
+        </ul>
+        <div class="worldmodel-chip-row">
+          <span class="worldmodel-chip">world_model profile</span>
+          <span class="worldmodel-chip">HYWorld</span>
+          <span class="worldmodel-chip">WorldMirror</span>
+          <span class="worldmodel-chip">Blender contract</span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add the HYWorld / WorldMirror 3D scene reconstruction section to `web/index.html`, which is the GitHub Pages homepage entrypoint.
- 将 HYWorld / WorldMirror 3D 场景重建板块添加到 `web/index.html`，也就是 GitHub Pages 首页入口文件。

- Keep the section aligned with the existing Claude warm-canvas design and reuse the already committed `web/images/readme/3D-build.png` pipeline figure.
- 保持该板块与现有 Claude 暖色画布设计一致，并复用已提交的 `web/images/readme/3D-build.png` 流程图。

## Why
- PR #13 updated `web/index_claude.html`, but the public project page at `https://pris-cv.github.io/DataEvolver/` loads `web/index.html`, so the homepage did not change.
- PR #13 更新的是 `web/index_claude.html`，但公开项目页面 `https://pris-cv.github.io/DataEvolver/` 加载的是 `web/index.html`，因此首页没有变化。

## Validation
- Ran `git diff --check`.
- 已运行 `git diff --check`。

- Verified the `#worldmodel` anchor, navigation link, and `images/readme/3D-build.png` image reference in `web/index.html`.
- 已验证 `web/index.html` 中的 `#worldmodel` 锚点、导航链接和 `images/readme/3D-build.png` 图片引用。

- Scanned the homepage diff for private server paths, tokens, GPU identifiers, and internal run-version strings; no matches were found.
- 已扫描首页 diff 中的服务器私有路径、token、GPU 标识和内部运行版本号；未发现匹配项。