### PR TITLE
[codex] Add Blender MCP onboarding

### DIFF
--- a/.agents/skills/dataevolver-onboarding/SKILL.md
+++ b/.agents/skills/dataevolver-onboarding/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dataevolver-onboarding
+description: Guide a lightweight DataEvolver setup interview and dry-run deployment handoff. Use when a user wants quick DataEvolver onboarding, server/environment discovery, default or custom model setup planning, Hugging Face token-safe download planning, or generation of local ENVIRONMENT.md and env.config.json setup profiles.
+---
+
+# DataEvolver Onboarding
+
+Use this skill to help a user quickly become ready to run DataEvolver without overwhelming them with the full environment surface. Keep the first pass light: interview, write a local profile, and hand off a dry-run deployment plan. Do not store secrets.
+
+## Workflow
+
+1. Ask at most five setup questions:
+   - Target route: `quick_demo`, `t2i`, `edit`, `t2v`, `blender_3d`, `vlm_review`, `full_pipeline`, `blender_mcp`, or `custom`.
+   - Runtime location: local Linux path, remote SSH alias plus project path, or not cloned yet.
+   - Install policy: inspect only, generate plan, install Python deps, download models, or full setup later.
+   - Model strategy: default DataEvolver models, existing paths, custom replacement models, or skip for now.
+   - Work/output paths: default `runtime/`, user path, or remote path.
+2. Do not ask tool-version questions in the interview. Let the demo script probe Python, `uv`, `uvx`, `conda`, `hf`, GPU, and Blender availability.
+3. Summarize known values, missing blockers, and the selected profile: `quick`, `default`, `full`, or `custom`.
+4. Generate or update `.dataevolver/local/ENVIRONMENT.md` and `.dataevolver/local/env.config.json` only when the user asks to save the profile.
+5. Hand off to the main agent with the demo command:
+   `bash scripts/bootstrap_dataevolver_default.sh --profile <profile> --dry-run --write-local-config`
+6. Tell the user that v0 is dry-run only: it prints install/download/config plans but does not install dependencies, download model weights, or launch long jobs.
+
+## Profiles
+
+- `quick`: environment probes and a dry-run route only.
+- `default`: current core pipeline defaults: Qwen-Image-2512, SAM3, Hunyuan3D-2.1, DINOv2 Giant, Qwen3.5-35B-A3B, and Blender.
+- `full`: `default` plus Qwen-Image-Edit-2511 and Wan2.1-T2V.
+- `custom`: record user-supplied model replacements as `needs_check`; do not perform compatibility review during onboarding.
+- `blender_mcp`: optional operator/debug profile for remote Blender MCP control. It configures Codex-to-Blender inspection tools, viewport screenshots, and temporary Blender Python execution; it is not the production Stage 4 render path and must not change default pipeline behavior.
+
+## Safety Rules
+
+- Never write Hugging Face, OpenAI, Anthropic, SSH, cookie, or API tokens to project files.
+- Mention `HF_TOKEN` only as a shell environment variable for future real downloads.
+- Treat SAM3 and other gated models as access-dependent; ask the user to obtain access instead of trying to bypass it.
+- Treat missing `uv`, `uvx`, `conda`, `hf`, `nvidia-smi`, or `blender` as non-blocking in v0. Surface them as next actions for real setup.
+- Do not modify `CLAUDE.md`; the main agent may decide later whether to sync selected non-sensitive facts.
+- If the user asks for real installation or real downloads, first use the demo script output as the plan and ask for explicit confirmation in the main conversation.
+- Prefer `uvx --from huggingface_hub hf download ...` for printed Hugging Face download plans, with `hf download ...` as fallback. Do not execute either command in v0.
+- For `blender_mcp`, do not write the user's global Codex config automatically. Generate `.dataevolver/local/blender_mcp.codex.toml` and ask the user to review/copy it.
+- For `blender_mcp`, do not start remote Blender or install remote system packages during onboarding. Print preflight/start commands only unless the user explicitly asks for real setup outside the dry-run flow.
+
+## Known V1 Requirements
+
+- Source or export environment-variable overrides before real one-click setup runs legacy pipeline stages:
+  `QWEN_IMAGE_MODEL_PATH`, `SAM3_CKPT`, `SAM3_DIR`, `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT`, and `VLM_MODEL_PATH`.
+- Install SAM3 and Hunyuan3D repo-specific dependencies only after target-host preflight.
+- Compile Hunyuan3D CUDA/C++ extensions only after CUDA/nvcc compatibility is confirmed.
+
+## Local Profile Contents
+
+`ENVIRONMENT.md` should be human-readable and include:
+
+- Selected profile and target workflow.
+- Runtime location and workspace/model roots.
+- Install policy.
+- Model choices and missing values.
+- Tooling status and missing commands.
+- Hugging Face gated/access-dependent repos.
+- Runtime path override plan for v1.
+- Optional operator configuration such as `operators.blender_mcp` when the selected route is `blender_mcp`.
+- Next actions for the main agent.
+
+`env.config.json` should include:
+
+- `profile`, `target_workflow`, `runtime_location`, `install_policy`
+- `model_root`, `workspace_root`
+- `tooling_status`, `models`, `custom_models`, `access_requirements`
+- `operators.blender_mcp` for the `blender_mcp` profile, including `enabled`, `connection_mode`, `ssh_alias`, `remote_root`, `remote_blender_bin`, `remote_addon_dir`, `remote_port`, `remote_uvx`, `tmux_session`, and `codex_mcp_server_name`
+- `path_override_plan`, `v1_blockers`, `next_actions`, `generated_at`
+
+Keep both files concise. Use `unknown`, `not_requested`, or `needs_check` instead of blocking onboarding when the user is unsure.

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ notion-weekly/
 
 # Internal docs, intermediate results, and deliverables
 docs/
+!docs/
+!docs/BLENDER_MCP_REMOTE.md
 deliverables/
 v6_staging/
 mcp-servers/
@@ -67,3 +69,13 @@ CONTRIBUTING_CN.md
 README_CN.md
 memory/
 skills/
+
+# Local onboarding outputs and external tool checkouts
+.dataevolver/local/
+external/
+
+# Repository-provided onboarding skill
+!.agents/
+!.agents/skills/
+!.agents/skills/dataevolver-onboarding/
+!.agents/skills/dataevolver-onboarding/**

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ cd DataEvolver
 bash pipeline/run_all.sh
 ```
 
+Optional Blender MCP operator setup for Codex-controlled remote Blender debugging:
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile blender_mcp \
+  --dry-run \
+  --write-local-config
+```
+
+This writes `.dataevolver/local/blender_mcp.codex.toml` and remote Blender preflight/start instructions. Blender MCP is for interactive scene diagnosis, viewport screenshots, temporary Blender Python execution, and lighting/camera/material experiments; production dataset generation still uses DataEvolver pipeline scripts and reviewed `BLENDER_BIN` configuration. See [`docs/BLENDER_MCP_REMOTE.md`](docs/BLENDER_MCP_REMOTE.md).
+
 ---
 
 ## Project Structure

--- a/README_zh.md
+++ b/README_zh.md
@@ -86,6 +86,17 @@ cd DataEvolver
 bash pipeline/run_all.sh
 ```
 
+可选的 Blender MCP operator 配置，用于 Codex 控制远端 Blender 调试：
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile blender_mcp \
+  --dry-run \
+  --write-local-config
+```
+
+这会写入 `.dataevolver/local/blender_mcp.codex.toml`，并生成远端 Blender 预检/启动说明。Blender MCP 用于交互式场景诊断、viewport 截图、临时执行 Blender Python，以及快速调试灯光/相机/材质；正式数据集生成仍走 DataEvolver pipeline 脚本和已审查的 `BLENDER_BIN` 配置。详见 [`docs/BLENDER_MCP_REMOTE.md`](docs/BLENDER_MCP_REMOTE.md)。
+
 ---
 
 ## 项目结构

--- a/docs/BLENDER_MCP_REMOTE.md
+++ b/docs/BLENDER_MCP_REMOTE.md
@@ -1,0 +1,105 @@
+# Blender MCP Remote Rendering
+
+DataEvolver can expose a remote Blender GUI session to Codex through
+`ahujasid/blender-mcp`. This is an optional operator tool. It does not change the
+default Stage 4 pipeline or any model execution path.
+
+## Local Install
+
+Start with the dry-run onboarding profile:
+
+```bash
+bash scripts/bootstrap_dataevolver_default.sh \
+  --profile blender_mcp \
+  --dry-run \
+  --write-local-config
+```
+
+This writes:
+
+- `.dataevolver/local/env.config.json`
+- `.dataevolver/local/ENVIRONMENT.md`
+- `.dataevolver/local/env.sh.example`
+- `.dataevolver/local/blender_mcp.codex.toml`
+
+The upstream repository is kept as a local checkout:
+
+```bash
+git clone https://github.com/ahujasid/blender-mcp.git external/blender-mcp
+```
+
+The local checkout is kept for auditing the exact addon/server code and for
+copying `addon.py` to the remote machine. For Codex Desktop, the preferred MCP
+server mode is SSH stdio: Codex starts `uvx blender-mcp` on the remote host, and
+that remote MCP process connects to the remote Blender addon over
+`127.0.0.1:9876`.
+
+## Remote Blender Session
+
+Blender MCP needs a non-background Blender process. On a headless server, start
+Blender under Xvfb instead of using `blender -b`.
+
+Set the target for your own remote Blender host. These are placeholders; keep
+site-specific aliases and filesystem paths in your shell or in
+`.dataevolver/local/env.sh.example`, not in committed files.
+
+```bash
+export DATAEVOLVER_SSH_BIN=ssh.exe
+export DATAEVOLVER_SCP_BIN=scp.exe
+export DATAEVOLVER_BLENDER_MCP_REMOTE=my-blender-server
+export DATAEVOLVER_REMOTE_ROOT=/path/to/DataEvolver
+export DATAEVOLVER_REMOTE_BLENDER_BIN=/path/to/blender
+```
+
+Start the remote addon:
+
+```bash
+scripts/setup_blender_mcp_remote.sh start
+scripts/setup_blender_mcp_remote.sh status
+```
+
+Optional tunnel mode for manual socket debugging:
+
+```bash
+scripts/setup_blender_mcp_remote.sh tunnel
+```
+
+The tunnel forwards local `127.0.0.1:9876` to the remote Blender addon. This is
+not the default Codex setup because the SSH stdio mode avoids a long-lived local
+tunnel.
+
+```text
+BLENDER_HOST=127.0.0.1
+BLENDER_PORT=9876
+```
+
+Stop the remote Blender session:
+
+```bash
+scripts/setup_blender_mcp_remote.sh stop
+```
+
+## Codex MCP Config
+
+The generated `.dataevolver/local/blender_mcp.codex.toml` starts the MCP server on the remote host:
+
+```toml
+[mcp_servers.blender]
+command = "ssh.exe"
+args = ["my-blender-server", "env", "BLENDER_HOST=127.0.0.1", "BLENDER_PORT=9876", "UV_PYTHON_PREFERENCE=only-managed", "uvx", "--python", "3.11", "blender-mcp"]
+startup_timeout_sec = 30
+tool_timeout_sec = 240
+```
+
+Restart Codex after editing the config so it reloads MCP servers.
+
+Do not let the bootstrap script edit global Codex config directly. Review and copy the generated snippet into the user's own Codex config.
+
+## Notes
+
+- Keep only one Blender MCP client connected to a Blender addon at a time.
+- Do not store API keys for Sketchfab, Hyper3D, Hunyuan3D, or other providers in
+  repository files. Pass them through the remote shell environment only when
+  needed.
+- Do not commit lab hostnames, private mount points, local drive paths, or
+  user-specific Blender binary paths. Override the placeholder values locally.

--- a/scripts/blender_mcp_bootstrap.py
+++ b/scripts/blender_mcp_bootstrap.py
@@ -1,0 +1,51 @@
+"""Start the Blender MCP addon from a checked-out addon.py file.
+
+Run this with a non-background Blender process, usually under Xvfb on a
+headless remote server:
+
+    xvfb-run -a blender --python scripts/blender_mcp_bootstrap.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+
+def _load_addon(addon_path: Path):
+    spec = importlib.util.spec_from_file_location("dataevolver_blender_mcp_addon", addon_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Blender MCP addon from {addon_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    addon_env = os.environ.get("BLENDER_MCP_ADDON", "").strip()
+    if addon_env:
+        addon_path = Path(addon_env).expanduser()
+    else:
+        addon_path = Path(__file__).resolve().parent / "addon.py"
+    if not addon_path.exists():
+        raise FileNotFoundError(f"BLENDER_MCP_ADDON does not exist: {addon_path}")
+
+    port = int(os.environ.get("BLENDER_MCP_PORT", "9876"))
+    addon = _load_addon(addon_path)
+    addon.register()
+
+    # The addon creates bpy.types.blendermcp_server during register().
+    import bpy  # type: ignore
+
+    bpy.context.scene.blendermcp_port = port
+    server = getattr(bpy.types, "blendermcp_server", None)
+    if server is not None and getattr(server, "port", port) != port:
+        server.stop()
+        bpy.types.blendermcp_server = addon.BlenderMCPServer(port=port)
+        bpy.types.blendermcp_server.start()
+
+    print(f"DataEvolver Blender MCP bootstrap ready on 127.0.0.1:{port}")
+
+
+main()

--- a/scripts/bootstrap_dataevolver_default.sh
+++ b/scripts/bootstrap_dataevolver_default.sh
@@ -1,0 +1,1000 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PROFILE="quick"
+MODEL_ROOT="${DATAEVOLVER_MODEL_ROOT:-${ROOT}/runtime/model_hub}"
+WORKSPACE_ROOT="${DATAEVOLVER_WORKSPACE_ROOT:-${ROOT}}"
+PYTHON_BACKEND="auto"
+DRY_RUN=1
+WRITE_LOCAL_CONFIG=0
+BLENDER_MCP_REMOTE="${DATAEVOLVER_BLENDER_MCP_REMOTE:-my-blender-server}"
+BLENDER_MCP_REMOTE_ROOT="${DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT:-${DATAEVOLVER_REMOTE_ROOT:-/path/to/DataEvolver}}"
+BLENDER_MCP_REMOTE_BLENDER_BIN="${DATAEVOLVER_REMOTE_BLENDER_BIN:-/path/to/blender}"
+BLENDER_MCP_REMOTE_PORT="${BLENDER_MCP_REMOTE_PORT:-9876}"
+BLENDER_MCP_REMOTE_UVX="${BLENDER_MCP_REMOTE_UVX:-uvx}"
+BLENDER_MCP_TMUX_SESSION="${BLENDER_MCP_TMUX_SESSION:-dataevolver-blender-mcp}"
+BLENDER_MCP_REMOTE_ADDON_DIR="${DATAEVOLVER_BLENDER_MCP_REMOTE_ADDON_DIR:-${BLENDER_MCP_REMOTE_ROOT}/.dataevolver/blender-mcp}"
+BLENDER_MCP_CODEX_SERVER_NAME="${BLENDER_MCP_CODEX_SERVER_NAME:-blender}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/bootstrap_dataevolver_default.sh [options]
+
+Dry-run only v0 demo. This script prints DataEvolver setup, install, model
+download, and config plans. It does not install dependencies, download model
+weights, write tokens, or launch long-running jobs.
+
+Options:
+  --dry-run                    Required behavior; enabled by default.
+  --profile quick|default|full|custom|blender_mcp
+  --model-root PATH            Target model root for the printed plan.
+  --workspace-root PATH        DataEvolver checkout path for the printed plan.
+  --python-backend auto|uv|conda
+  --write-local-config         Write .dataevolver/local demo profile files.
+  -h, --help                   Show this help.
+USAGE
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+quote() {
+  printf '%q' "$1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --profile)
+      [[ $# -ge 2 ]] || die "--profile requires a value"
+      PROFILE="$2"
+      shift 2
+      ;;
+    --model-root)
+      [[ $# -ge 2 ]] || die "--model-root requires a value"
+      MODEL_ROOT="$2"
+      shift 2
+      ;;
+    --workspace-root)
+      [[ $# -ge 2 ]] || die "--workspace-root requires a value"
+      WORKSPACE_ROOT="$2"
+      shift 2
+      ;;
+    --python-backend)
+      [[ $# -ge 2 ]] || die "--python-backend requires a value"
+      PYTHON_BACKEND="$2"
+      shift 2
+      ;;
+    --write-local-config)
+      WRITE_LOCAL_CONFIG=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+case "$PROFILE" in
+  quick|default|full|custom|blender_mcp) ;;
+  *) die "--profile must be one of: quick, default, full, custom, blender_mcp" ;;
+esac
+
+case "$PYTHON_BACKEND" in
+  auto|uv|conda) ;;
+  *) die "--python-backend must be one of: auto, uv, conda" ;;
+esac
+
+if [[ "$DRY_RUN" != "1" ]]; then
+  die "v0 is dry-run only"
+fi
+
+WORKSPACE_ROOT="$(cd "$WORKSPACE_ROOT" 2>/dev/null && pwd || printf '%s' "$WORKSPACE_ROOT")"
+MODEL_ROOT="${MODEL_ROOT%/}"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+cmd_status() {
+  if has_cmd "$1"; then
+    printf 'present: %s -> %s\n' "$1" "$(command -v "$1")"
+  else
+    printf 'missing: %s\n' "$1"
+  fi
+}
+
+print_actionable_gaps() {
+  local gaps=0
+  printf '\nActionable gaps for real setup (non-blocking in dry-run):\n'
+  if ! has_cmd python3 && ! has_cmd python; then
+    printf '  - python: missing; real setup and config writing need Python 3.10+.\n'
+    gaps=1
+  fi
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    if ! has_cmd ssh && ! has_cmd ssh.exe; then
+      printf '  - ssh: missing; Blender MCP SSH stdio mode needs ssh or ssh.exe.\n'
+      gaps=1
+    fi
+    if [[ "$gaps" == "0" ]]; then
+      printf '  - none detected for local dry-run. Remote uvx, Xvfb, tmux, and Blender are checked by the remote preflight commands.\n'
+    fi
+    return
+  fi
+  if ! has_cmd uv && ! has_cmd conda; then
+    printf '  - python environment backend: missing uv and conda; install uv for the fastest default path or provide conda.\n'
+    gaps=1
+  elif ! has_cmd uv; then
+    printf '  - uv: missing; real setup will need the conda fallback unless uv is installed.\n'
+    gaps=1
+  fi
+  if ! has_cmd uvx && ! has_cmd hf; then
+    printf '  - Hugging Face CLI: missing uvx and hf; real model downloads need one of them.\n'
+    gaps=1
+  elif ! has_cmd hf; then
+    printf '  - hf CLI: missing; real downloads can still use uvx --from huggingface_hub hf if uvx is available.\n'
+    gaps=1
+  fi
+  if ! has_cmd blender; then
+    printf '  - blender: missing; 3D render/export routes need Blender before real pipeline runs.\n'
+    gaps=1
+  fi
+  if ! has_cmd nvidia-smi; then
+    printf '  - nvidia-smi: missing; GPU availability is unknown and must be confirmed on the target host.\n'
+    gaps=1
+  fi
+  if ! has_cmd git; then
+    printf '  - git: missing; repo-based model/runtime dependencies need git.\n'
+    gaps=1
+  fi
+  if ! has_cmd curl; then
+    printf '  - curl: missing; installer/bootstrap commands may need curl.\n'
+    gaps=1
+  fi
+  if [[ "$gaps" == "0" ]]; then
+    printf '  - none detected for the dry-run host. Still confirm CUDA, disk, and HF access before real setup.\n'
+  fi
+}
+
+print_probe_plan() {
+  section "preflight"
+  printf 'mode: dry-run only; no install/download/long job will run\n'
+  printf 'profile: %s\n' "$PROFILE"
+  printf 'workspace_root: %s\n' "$WORKSPACE_ROOT"
+  printf 'model_root: %s\n' "$MODEL_ROOT"
+  printf 'python_backend: %s\n' "$PYTHON_BACKEND"
+  printf '\nDetected commands:\n'
+  for name in uname git curl ssh ssh.exe python3 python uv uvx conda nvidia-smi blender hf; do
+    cmd_status "$name"
+  done
+  print_actionable_gaps
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf '\nBlender MCP preflight commands to run before real setup:\n'
+    printf '  python3 --version || python --version\n'
+    printf '  ssh -V || ssh.exe -V\n'
+    printf '  ssh %s "command -v uvx; command -v xvfb-run; command -v tmux; test -x %s"\n' "$(quote "$BLENDER_MCP_REMOTE")" "$(quote "$BLENDER_MCP_REMOTE_BLENDER_BIN")"
+    printf '  ssh %s "env BLENDER_HOST=127.0.0.1 BLENDER_PORT=%s %s --python 3.11 blender-mcp"\n' "$(quote "$BLENDER_MCP_REMOTE")" "$BLENDER_MCP_REMOTE_PORT" "$(quote "$BLENDER_MCP_REMOTE_UVX")"
+  else
+    printf '\nCommands to run before real setup:\n'
+    printf '  uname -a\n'
+    printf '  nvidia-smi --query-gpu=name,memory.total,memory.used --format=csv\n'
+    printf '  python3 --version || python --version\n'
+    printf '  uv --version || conda --version\n'
+    printf '  uvx --from huggingface_hub hf --help || hf --help\n'
+    printf '  blender --version\n'
+    printf '  hf auth whoami\n'
+  fi
+}
+
+print_env_plan() {
+  section "env plan"
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf 'Blender MCP operator profile: no Python model environment will be installed in dry-run v0.\n'
+    printf 'Remote Blender must run as a non-background GUI process, usually under Xvfb on headless servers.\n'
+    printf '\nRemote operator environment variables to review:\n'
+    printf '  DATAEVOLVER_BLENDER_MCP_REMOTE=%s\n' "$BLENDER_MCP_REMOTE"
+    printf '  DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT=%s\n' "$BLENDER_MCP_REMOTE_ROOT"
+    printf '  DATAEVOLVER_REMOTE_BLENDER_BIN=%s\n' "$BLENDER_MCP_REMOTE_BLENDER_BIN"
+    printf '  BLENDER_MCP_REMOTE_PORT=%s\n' "$BLENDER_MCP_REMOTE_PORT"
+    printf '  BLENDER_MCP_REMOTE_UVX=%s\n' "$BLENDER_MCP_REMOTE_UVX"
+    printf '  BLENDER_MCP_TMUX_SESSION=%s\n' "$BLENDER_MCP_TMUX_SESSION"
+    return
+  fi
+  if [[ "$PYTHON_BACKEND" == "uv" || "$PYTHON_BACKEND" == "auto" ]]; then
+    printf 'Preferred uv plan:\n'
+    printf '  cd %s\n' "$(quote "$WORKSPACE_ROOT")"
+    printf '  uv venv .venv --python 3.10 --system-site-packages\n'
+    printf '  source .venv/bin/activate\n'
+    printf '  python -c "import torch; print(torch.__version__, torch.cuda.is_available())"\n'
+    printf '  # Fallback only if the torch import above fails or has no usable CUDA:\n'
+    printf '  uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121\n'
+    printf '  uv pip install "numpy<2" "tokenizers==0.22.1" diffsynth transformers accelerate diffusers safetensors pillow opencv-python scipy scikit-image imageio trimesh rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan iopath timm ftfy opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http\n'
+  fi
+  if [[ "$PYTHON_BACKEND" == "conda" || "$PYTHON_BACKEND" == "auto" ]]; then
+    printf '\nConda fallback plan:\n'
+    printf '  conda create -n dataevolver python=3.10 -y\n'
+    printf '  conda activate dataevolver\n'
+    printf '  python -c "import torch; print(torch.__version__, torch.cuda.is_available())" || true\n'
+    printf '  pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121\n'
+    printf '  pip install "numpy<2" "tokenizers==0.22.1" diffsynth transformers accelerate diffusers safetensors pillow opencv-python scipy scikit-image imageio trimesh rembg[gpu] anthropic qwen-vl-utils lpips basicsr realesrgan iopath timm ftfy opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http\n'
+  fi
+  printf '\nTool bootstrap plan if commands are missing (printed only):\n'
+  printf '  # Install uv for the fastest Python environment path:\n'
+  printf '  curl -LsSf https://astral.sh/uv/install.sh | sh\n'
+  printf '  # Verify the Hugging Face CLI without persisting a token:\n'
+  printf '  uvx --from huggingface_hub hf --help || hf --help\n'
+  printf '  # Optional standalone Hugging Face CLI installer:\n'
+  printf '  curl -LsSf https://hf.co/cli/install.sh | bash\n'
+  printf '\nSource and native-extension plan after target-host preflight:\n'
+  printf '  # Keep source checkouts separate from weight directories.\n'
+  printf '  git clone --depth 1 https://github.com/facebookresearch/sam3.git .dataevolver/local/vendor/sam3-src\n'
+  printf '  git clone --depth 1 https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1.git .dataevolver/local/vendor/Hunyuan3D-2.1-src\n'
+  printf '  test -f "$HUNYUAN3D_REPO/requirements.txt" && uv pip install -r "$HUNYUAN3D_REPO/requirements.txt"\n'
+  printf '  uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"\n'
+  printf '  cd "$HUNYUAN3D_REPO/hy3dpaint/DifferentiableRenderer" && bash compile_mesh_painter.sh\n'
+}
+
+model_line() {
+  local role="$1"
+  local name="$2"
+  local repo="$3"
+  local subdir="$4"
+  local gated="$5"
+  local env_name="$6"
+  local target="${MODEL_ROOT}/${subdir}"
+  printf '%s|%s|%s|%s|%s|%s\n' "$role" "$name" "$repo" "$target" "$gated" "$env_name"
+}
+
+model_manifest() {
+  if [[ "$PROFILE" == "quick" || "$PROFILE" == "custom" || "$PROFILE" == "blender_mcp" ]]; then
+    return 0
+  fi
+
+  model_line "t2i_generator" "Qwen-Image-2512" "Qwen/Qwen-Image-2512" "Qwen-Image-2512" "no" "QWEN_IMAGE_MODEL_PATH"
+  model_line "segmenter" "SAM3" "facebook/sam3" "sam3" "yes" "SAM3_CKPT"
+  model_line "image_to_3d" "Hunyuan3D-2.1" "tencent/Hunyuan3D-2.1" "Hunyuan3D-2.1" "no" "MODEL_HUB"
+  model_line "image_to_3d_dino" "DINOv2 Giant" "facebook/dinov2-giant" "dinov2-giant" "no" "DINO_MODEL_PATH"
+  model_line "world_model" "HY-World-2.0" "Tencent-Hunyuan/HY-World-2.0" "HY-World-2.0" "no" "HYWORLD_WEIGHTS"
+  model_line "world_depth" "MoGe-2 VitL Normal" "Ruicheng/moge-2-vitl-normal" "moge-2-vitl-normal" "no" "HYWORLD_MOGE_MODEL_PATH"
+  model_line "world_sky_mask" "ZIM Anything ViT-L" "naver-iv/zim-anything-vitl" "zim-anything-vitl" "no" "HYWORLD_ZIM_MODEL_PATH"
+  model_line "world_detector" "GroundingDINO Tiny" "IDEA-Research/grounding-dino-tiny" "grounding-dino-tiny" "no" "HYWORLD_GROUNDING_DINO_MODEL_PATH"
+  model_line "world_stereo" "WorldStereo" "hanshanxue/WorldStereo" "WorldStereo" "no" "HYWORLD_WORLDSTEREO_PATH"
+  model_line "vlm_reviewer" "Qwen3.5-35B-A3B" "Qwen/Qwen3.5-35B-A3B" "Qwen3.5-35B-A3B" "access-dependent" "VLM_MODEL_PATH"
+
+  if [[ "$PROFILE" == "full" ]]; then
+    model_line "image_edit_generator" "Qwen-Image-Edit-2511" "Qwen/Qwen-Image-Edit-2511" "Qwen-Image-Edit-2511" "no" "QWEN_IMAGE_EDIT_MODEL_PATH"
+    model_line "t2v_generator" "Wan2.1-T2V-1.3B-Diffusers" "Wan-AI/Wan2.1-T2V-1.3B-Diffusers" "Wan2.1-T2V-1.3B-Diffusers" "no" "WAN_T2V_MODEL_PATH"
+  fi
+}
+
+print_model_plan() {
+  section "model plan"
+  if [[ "$PROFILE" == "quick" ]]; then
+    printf 'quick profile: no model downloads planned. Use dry-run routes only.\n'
+    return
+  fi
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf 'blender_mcp profile: no model downloads planned. This profile configures an optional Blender operator/debug MCP server only.\n'
+    return
+  fi
+  if [[ "$PROFILE" == "custom" ]]; then
+    printf 'custom profile: no default model downloads planned in v0.\n'
+    printf 'Record replacement models as custom_models with status=needs_check in env.config.json.\n'
+    return
+  fi
+
+  printf 'All commands below are printed only; they are not executed in v0.\n'
+  printf 'HF token policy: set HF_TOKEN in the shell for real downloads; never write it to project files.\n\n'
+  printf 'Access checks before real downloads (printed only):\n'
+  printf '  test -n "${HF_TOKEN:-}" || echo "HF_TOKEN is not set"\n'
+  printf '  uvx --from huggingface_hub hf auth whoami || hf auth whoami\n'
+  printf '  # For gated/access-dependent repos, request access on Hugging Face before downloading.\n\n'
+  while IFS='|' read -r role name repo target gated env_name; do
+    [[ -n "$role" ]] || continue
+    printf '%s\n' "- role: $role"
+    printf '  model: %s\n' "$name"
+    printf '  hf_repo: %s\n' "$repo"
+    printf '  target: %s\n' "$target"
+    printf '  gated_or_access_dependent: %s\n' "$gated"
+    printf '  env: %s\n' "$env_name"
+    printf '  uvx command: HF_TOKEN="${HF_TOKEN:?set HF_TOKEN for real downloads}" uvx --from huggingface_hub hf download %s --local-dir %s\n' "$(quote "$repo")" "$(quote "$target")"
+    printf '  fallback command: HF_TOKEN="${HF_TOKEN:?set HF_TOKEN for real downloads}" hf download %s --local-dir %s\n' "$(quote "$repo")" "$(quote "$target")"
+  done < <(model_manifest)
+
+}
+
+print_blender_mcp_plan() {
+  [[ "$PROFILE" == "blender_mcp" ]] || return 0
+  section "blender mcp operator plan"
+  printf 'Purpose: optional interactive Blender control for scene diagnosis, viewport screenshots, temporary Blender Python, and lighting/camera/material tuning.\n'
+  printf 'Boundary: production dataset generation still uses DataEvolver pipeline scripts and BLENDER_BIN; MCP changes must be written back to code/config before production use.\n'
+  printf '\nRemote addon setup plan (printed only):\n'
+  printf '  git clone https://github.com/ahujasid/blender-mcp.git external/blender-mcp\n'
+  printf '  DATAEVOLVER_BLENDER_MCP_REMOTE=%s \\\n' "$(quote "$BLENDER_MCP_REMOTE")"
+  printf '  DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT=%s \\\n' "$(quote "$BLENDER_MCP_REMOTE_ROOT")"
+  printf '  DATAEVOLVER_REMOTE_BLENDER_BIN=%s \\\n' "$(quote "$BLENDER_MCP_REMOTE_BLENDER_BIN")"
+  printf '  BLENDER_MCP_REMOTE_PORT=%s \\\n' "$(quote "$BLENDER_MCP_REMOTE_PORT")"
+  printf '  BLENDER_MCP_TMUX_SESSION=%s \\\n' "$(quote "$BLENDER_MCP_TMUX_SESSION")"
+  printf '  bash scripts/setup_blender_mcp_remote.sh start\n'
+  printf '\nRemote dependency preflight (printed only):\n'
+  printf '  ssh %s "command -v uvx; command -v xvfb-run; command -v tmux; test -x %s"\n' "$(quote "$BLENDER_MCP_REMOTE")" "$(quote "$BLENDER_MCP_REMOTE_BLENDER_BIN")"
+  printf '\nCodex MCP config snippet will be written to .dataevolver/local/blender_mcp.codex.toml when --write-local-config is used.\n'
+}
+
+print_config_plan() {
+  section "config plan"
+  printf 'Local files when --write-local-config is used:\n'
+  printf '  .dataevolver/local/ENVIRONMENT.md\n'
+  printf '  .dataevolver/local/env.config.json\n'
+  printf '  .dataevolver/local/env.sh.example\n'
+  printf '  .dataevolver/local/production_profile.json\n'
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf '  .dataevolver/local/blender_mcp.codex.toml\n'
+  fi
+  printf '\nNon-sensitive variables to export later:\n'
+  printf '  DATAEVOLVER_MODEL_ROOT=%s\n' "$MODEL_ROOT"
+  printf '  DATAEVOLVER_WORKSPACE_ROOT=%s\n' "$WORKSPACE_ROOT"
+  printf '  BLENDER_BIN=/path/to/blender\n'
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf '  DATAEVOLVER_BLENDER_MCP_REMOTE=%s\n' "$BLENDER_MCP_REMOTE"
+    printf '  DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT=%s\n' "$BLENDER_MCP_REMOTE_ROOT"
+    printf '  DATAEVOLVER_REMOTE_BLENDER_BIN=%s\n' "$BLENDER_MCP_REMOTE_BLENDER_BIN"
+    printf '  BLENDER_MCP_REMOTE_PORT=%s\n' "$BLENDER_MCP_REMOTE_PORT"
+    printf '  BLENDER_MCP_REMOTE_UVX=%s\n' "$BLENDER_MCP_REMOTE_UVX"
+    printf '  BLENDER_MCP_TMUX_SESSION=%s\n' "$BLENDER_MCP_TMUX_SESSION"
+  fi
+  if [[ "$PROFILE" == "default" || "$PROFILE" == "full" ]]; then
+    printf '  QWEN_IMAGE_MODEL_PATH=%s/Qwen-Image-2512\n' "$MODEL_ROOT"
+    printf '  QWEN_IMAGE_EDIT_MODEL_PATH=%s/Qwen-Image-Edit-2511\n' "$MODEL_ROOT"
+    printf '  SAM3_CKPT=%s/sam3/sam3.pt\n' "$MODEL_ROOT"
+    printf '  SAM3_DIR=<source checkout or package path for SAM3>\n'
+    printf '  HUNYUAN3D_REPO=<clone path for Tencent-Hunyuan/Hunyuan3D-2.1>\n'
+    printf '  MODEL_HUB=%s/Hunyuan3D-2.1\n' "$MODEL_ROOT"
+    printf '  PAINT_MODEL_HUB=%s/Hunyuan3D-2.1\n' "$MODEL_ROOT"
+    printf '  DINO_MODEL_PATH=%s/dinov2-giant\n' "$MODEL_ROOT"
+    printf '  REALESRGAN_CKPT=<clone path for Tencent-Hunyuan/Hunyuan3D-2.1>/hy3dpaint/ckpt/RealESRGAN_x4plus.pth\n'
+    printf '  HYWORLD_SRC=<clone path for Tencent-Hunyuan/HY-World-2.0 source>\n'
+    printf '  HYWORLD_WEIGHTS=%s/HY-World-2.0\n' "$MODEL_ROOT"
+    printf '  HYWORLD_MOGE_MODEL_PATH=%s/moge-2-vitl-normal\n' "$MODEL_ROOT"
+    printf '  HYWORLD_ZIM_MODEL_PATH=%s/zim-anything-vitl\n' "$MODEL_ROOT"
+    printf '  HYWORLD_GROUNDING_DINO_MODEL_PATH=%s/grounding-dino-tiny\n' "$MODEL_ROOT"
+    printf '  HYWORLD_SAM3_MODEL_PATH=%s/sam3\n' "$MODEL_ROOT"
+    printf '  HYWORLD_WORLDSTEREO_PATH=%s/WorldStereo\n' "$MODEL_ROOT"
+    printf '  VLM_MODEL_PATH=%s/Qwen3.5-35B-A3B\n' "$MODEL_ROOT"
+    printf '  STAGE3_PAINT_MAX_FACES=5000\n'
+    printf '  STAGE3_PAINT_REMESH_MODES=false\n'
+    printf '  STAGE3_PAINT_ATTEMPT_TIMEOUT_SEC=300\n'
+  fi
+  if [[ "$PROFILE" == "full" ]]; then
+    printf '  WAN_T2V_MODEL_PATH=%s/Wan2.1-T2V-1.3B-Diffusers\n' "$MODEL_ROOT"
+  fi
+  if [[ "$PROFILE" == "blender_mcp" ]]; then
+    printf '\nPipeline env overrides:\n'
+    printf '  none. Blender MCP is an operator/debug profile and does not change production Stage 4 rendering.\n'
+  else
+    printf '\nRuntime env overrides to source before real one-click setup:\n'
+    printf '  pipeline/stage2_t2i_generate.py: MODEL_PATH <- QWEN_IMAGE_MODEL_PATH\n'
+    printf '  pipeline/stage2_5_sam2_segment.py: SAM3_CKPT/SAM3_DIR <- env overrides\n'
+    printf '  pipeline/stage3_image_to_3d.py: HUNYUAN3D_REPO/MODEL_HUB/PAINT_MODEL_HUB/DINO_MODEL_PATH/REALESRGAN_CKPT <- env overrides\n'
+    printf '  pipeline/stage5_5_vlm_review.py: VLM_MODEL_PATH <- env override\n'
+    printf '  scene/render scripts: BLENDER_BIN <- env override\n'
+  fi
+}
+
+write_local_config() {
+  local out_dir="${WORKSPACE_ROOT}/.dataevolver/local"
+  local python_bin=""
+  if has_cmd python3; then
+    python_bin="$(command -v python3)"
+  elif has_cmd python; then
+    python_bin="$(command -v python)"
+  else
+    die "--write-local-config requires python3 or python for safe JSON writing"
+  fi
+
+  MODEL_MANIFEST="$(model_manifest)" \
+  BLENDER_MCP_REMOTE="$BLENDER_MCP_REMOTE" \
+  BLENDER_MCP_REMOTE_ROOT="$BLENDER_MCP_REMOTE_ROOT" \
+  BLENDER_MCP_REMOTE_BLENDER_BIN="$BLENDER_MCP_REMOTE_BLENDER_BIN" \
+  BLENDER_MCP_REMOTE_PORT="$BLENDER_MCP_REMOTE_PORT" \
+  BLENDER_MCP_REMOTE_UVX="$BLENDER_MCP_REMOTE_UVX" \
+  BLENDER_MCP_TMUX_SESSION="$BLENDER_MCP_TMUX_SESSION" \
+  BLENDER_MCP_REMOTE_ADDON_DIR="$BLENDER_MCP_REMOTE_ADDON_DIR" \
+  BLENDER_MCP_CODEX_SERVER_NAME="$BLENDER_MCP_CODEX_SERVER_NAME" \
+  "$python_bin" - "$PROFILE" "$WORKSPACE_ROOT" "$MODEL_ROOT" "$PYTHON_BACKEND" "$out_dir" <<'PY'
+import json
+import os
+import shutil
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+profile, workspace_root, model_root, python_backend, out_dir = sys.argv[1:6]
+out = Path(out_dir)
+out.mkdir(parents=True, exist_ok=True)
+
+models = []
+for line in os.environ.get("MODEL_MANIFEST", "").splitlines():
+    if not line.strip():
+        continue
+    role, name, repo, target, gated, env_name = line.split("|", 5)
+    models.append({
+        "role": role,
+        "name": name,
+        "hf_repo": repo,
+        "target_path": target,
+        "gated_or_access_dependent": gated,
+        "env": env_name,
+        "status": "planned_dry_run",
+    })
+
+tool_names = ["git", "curl", "python3", "python", "uv", "uvx", "conda", "hf", "nvidia-smi", "blender"]
+tooling_status = {
+    name: {
+        "status": "present" if shutil.which(name) else "missing",
+        "path": shutil.which(name),
+    }
+    for name in tool_names
+}
+
+blender_mcp_operator = {
+    "enabled": profile == "blender_mcp",
+    "connection_mode": "ssh_stdio",
+    "ssh_alias": os.environ.get("BLENDER_MCP_REMOTE", "my-blender-server"),
+    "remote_root": os.environ.get("BLENDER_MCP_REMOTE_ROOT", ""),
+    "remote_blender_bin": os.environ.get("BLENDER_MCP_REMOTE_BLENDER_BIN", ""),
+    "remote_addon_dir": os.environ.get("BLENDER_MCP_REMOTE_ADDON_DIR", ""),
+    "remote_port": int(os.environ.get("BLENDER_MCP_REMOTE_PORT", "9876")),
+    "remote_uvx": os.environ.get("BLENDER_MCP_REMOTE_UVX", "uvx"),
+    "tmux_session": os.environ.get("BLENDER_MCP_TMUX_SESSION", "dataevolver-blender-mcp"),
+    "codex_mcp_server_name": os.environ.get("BLENDER_MCP_CODEX_SERVER_NAME", "blender"),
+}
+
+path_override_plan = [
+    {
+        "file": "pipeline/stage2_t2i_generate.py",
+        "constant": "MODEL_PATH",
+        "env": "QWEN_IMAGE_MODEL_PATH",
+    },
+    {
+        "file": "pipeline/stage2_5_sam2_segment.py",
+        "constant": "SAM3_CKPT",
+        "env": "SAM3_CKPT",
+    },
+    {
+        "file": "pipeline/stage2_5_sam2_segment.py",
+        "constant": "SAM3_DIR",
+        "env": "SAM3_DIR",
+    },
+    {
+        "file": "pipeline/stage3_image_to_3d.py",
+        "constant": "HUNYUAN3D_REPO",
+        "env": "HUNYUAN3D_REPO",
+    },
+    {
+        "file": "pipeline/stage3_image_to_3d.py",
+        "constant": "MODEL_HUB",
+        "env": "MODEL_HUB",
+    },
+    {
+        "file": "pipeline/stage3_image_to_3d.py",
+        "constant": "PAINT_MODEL_HUB",
+        "env": "PAINT_MODEL_HUB",
+    },
+    {
+        "file": "pipeline/stage3_image_to_3d.py",
+        "constant": "DINO_MODEL_PATH",
+        "env": "DINO_MODEL_PATH",
+    },
+    {
+        "file": "pipeline/stage3_image_to_3d.py",
+        "constant": "REALESRGAN_CKPT",
+        "env": "REALESRGAN_CKPT",
+    },
+    {
+        "file": "pipeline/stage5_5_vlm_review.py",
+        "constant": "VLM_MODEL_PATH",
+        "env": "VLM_MODEL_PATH",
+    },
+    {
+        "file": "scene/render scripts",
+        "constant": "BLENDER_BIN",
+        "env": "BLENDER_BIN",
+    },
+]
+
+access_requirements = [
+    {
+        "name": model["name"],
+        "hf_repo": model["hf_repo"],
+        "requirement": model["gated_or_access_dependent"],
+        "action": "Confirm Hugging Face access and provide HF_TOKEN only at real download time.",
+    }
+    for model in models
+    if model["gated_or_access_dependent"] != "no"
+]
+
+if profile == "blender_mcp":
+    next_actions = [
+        "Review this dry-run Blender MCP operator plan with the user.",
+        "Review .dataevolver/local/blender_mcp.codex.toml and copy it into the user's Codex config only after confirmation.",
+        "Clone or refresh external/blender-mcp before copying addon.py to the remote host.",
+        "Run scripts/setup_blender_mcp_remote.sh start only after remote uvx, xvfb-run, tmux, and Blender preflight pass.",
+        "Restart Codex after adding the MCP config snippet.",
+    ]
+else:
+    next_actions = [
+        "Review this dry-run plan with the user.",
+        "Ask for HF_TOKEN only at real download time; never write it to project files.",
+    ]
+    if tooling_status["uv"]["status"] == "missing":
+        next_actions.append("Install uv for the fastest default Python environment path, or choose conda fallback.")
+    if tooling_status["uvx"]["status"] == "missing" and tooling_status["hf"]["status"] == "missing":
+        next_actions.append("Install uvx/uv or the standalone hf CLI before real Hugging Face downloads.")
+    if tooling_status["blender"]["status"] == "missing":
+        next_actions.append("Install or expose Blender before real 3D render/export routes.")
+    if tooling_status["nvidia-smi"]["status"] == "missing":
+        next_actions.append("Confirm GPU/CUDA on the target host before real model setup.")
+    if access_requirements:
+        next_actions.append("Confirm Hugging Face access for gated/access-dependent model repos.")
+    next_actions.append("Before real setup, source reviewed path overrides derived from env.sh.example.")
+    next_actions.append("Run the generated production profile through `scripts/dataevolver_production.py doctor` before starting workers.")
+    next_actions.append("Run smoke tests in order: preflight, import smoke, Stage 2, Stage 2.5, Stage 3 shape-only, Stage 3 textured, Stage 5.5 VLM loader.")
+
+target_workflow = {
+    "quick": "quick_demo",
+    "default": "full_core_pipeline",
+    "full": "all_default_routes",
+    "custom": "custom_model_planning",
+    "blender_mcp": "operator_blender_mcp",
+}[profile]
+
+payload = {
+    "profile": profile,
+    "target_workflow": target_workflow,
+    "runtime_location": {
+        "kind": "local_or_remote_path",
+        "workspace_root": workspace_root,
+    },
+    "install_policy": {
+        "mode": "dry_run_only",
+        "python_backend": python_backend,
+        "allow_real_install": False,
+        "allow_real_model_download": False,
+    },
+    "model_root": model_root,
+    "workspace_root": workspace_root,
+    "tooling_status": tooling_status,
+    "models": models,
+    "custom_models": [] if profile != "custom" else [{
+        "role": "unspecified",
+        "choice": "custom",
+        "status": "needs_check",
+        "notes": "Fill from onboarding interview before real deployment.",
+    }],
+    "operators": {
+        "blender_mcp": blender_mcp_operator,
+    },
+    "access_requirements": access_requirements,
+    "path_override_plan": path_override_plan,
+    "v1_blockers": [
+        "Source or export the path override variables before running the pipeline on a new host.",
+        "Keep SAM3 and Hunyuan3D source checkouts separate from downloaded weight directories.",
+        "Install SAM3 and Hunyuan3D repo-specific dependencies after target-host preflight.",
+        "Compile Hunyuan3D CUDA/C++ extensions only after CUDA/nvcc compatibility is known.",
+        "Run Stage 3 textured smoke with bounded paint settings before treating the host as production-ready.",
+    ] if profile != "blender_mcp" else [
+        "Blender MCP is an operator/debug tool and must not be treated as the production Stage 4 render path.",
+        "The remote Blender addon must run in a non-background Blender process, usually under Xvfb on headless servers.",
+        "Do not store Sketchfab, Hyper3D, Hunyuan3D, SSH, Hugging Face, OpenAI, or other credentials in project files.",
+    ],
+    "next_actions": next_actions,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+}
+
+(out / "env.config.json").write_text(
+    json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+    encoding="utf-8",
+)
+
+if profile == "blender_mcp":
+    production_profile = {
+        "schema": "dataevolver.production.v1",
+        "workspace_root": workspace_root,
+        "runtime_dir": str(Path(workspace_root) / ".dataevolver/runtime"),
+        "runtime": {},
+        "paths": {},
+        "offline": {"no_model_downloads": True, "hf_hub_offline": True},
+        "environment": {},
+        "import_checks": {},
+        "workers": [],
+        "health_endpoints": [],
+        "operators": {"blender_mcp": blender_mcp_operator},
+    }
+else:
+    production_profile = {
+    "schema": "dataevolver.production.v1",
+    "workspace_root": workspace_root,
+    "runtime_dir": str(Path(workspace_root) / ".dataevolver/runtime"),
+    "runtime": {
+        "dataevolver_python": str(Path(workspace_root) / ".venv/bin/python"),
+        "hyworld_python": str(Path(workspace_root) / ".venv-hyworld/bin/python"),
+        "blender_bin": shutil.which("blender") or "/path/to/blender",
+    },
+    "paths": {
+        "qwen_image_model": str(Path(model_root) / "Qwen-Image-2512"),
+        "sam3_checkpoint": str(Path(model_root) / "sam3/sam3.pt"),
+        "sam3_source": str(Path(workspace_root) / ".dataevolver/local/vendor/sam3-src"),
+        "hunyuan3d_source": str(Path(workspace_root) / ".dataevolver/local/vendor/Hunyuan3D-2.1-src"),
+        "hunyuan3d_weights": str(Path(model_root) / "Hunyuan3D-2.1"),
+        "dino_model": str(Path(model_root) / "dinov2-giant"),
+        "realesrgan_checkpoint": str(Path(workspace_root) / ".dataevolver/local/vendor/Hunyuan3D-2.1-src/hy3dpaint/ckpt/RealESRGAN_x4plus.pth"),
+        "hyworld_source": str(Path(workspace_root) / ".dataevolver/local/vendor/HY-World-2.0-src"),
+        "hyworld_weights": str(Path(model_root) / "HY-World-2.0"),
+        "hyworld_moge_model": str(Path(model_root) / "moge-2-vitl-normal"),
+        "hyworld_zim_model": str(Path(model_root) / "zim-anything-vitl"),
+        "hyworld_grounding_dino_model": str(Path(model_root) / "grounding-dino-tiny"),
+        "hyworld_sam3_model": str(Path(model_root) / "sam3"),
+        "hyworld_worldstereo_weights": str(Path(model_root) / "WorldStereo"),
+    },
+    "offline": {"no_model_downloads": True, "hf_hub_offline": True, "skip_hyworld_depth_models": False},
+    "environment": {
+        "QWEN_IMAGE_MODEL_PATH": str(Path(model_root) / "Qwen-Image-2512"),
+        "SAM3_CKPT": str(Path(model_root) / "sam3/sam3.pt"),
+        "SAM3_DIR": str(Path(workspace_root) / ".dataevolver/local/vendor/sam3-src"),
+        "HUNYUAN3D_REPO": str(Path(workspace_root) / ".dataevolver/local/vendor/Hunyuan3D-2.1-src"),
+        "MODEL_HUB": str(Path(model_root) / "Hunyuan3D-2.1"),
+        "PAINT_MODEL_HUB": str(Path(model_root) / "Hunyuan3D-2.1"),
+        "DINO_MODEL_PATH": str(Path(model_root) / "dinov2-giant"),
+        "REALESRGAN_CKPT": str(Path(workspace_root) / ".dataevolver/local/vendor/Hunyuan3D-2.1-src/hy3dpaint/ckpt/RealESRGAN_x4plus.pth"),
+        "HYWORLD_SRC": str(Path(workspace_root) / ".dataevolver/local/vendor/HY-World-2.0-src"),
+        "HYWORLD_WEIGHTS": str(Path(model_root) / "HY-World-2.0"),
+        "HYWORLD_MOGE_MODEL_PATH": str(Path(model_root) / "moge-2-vitl-normal"),
+        "HYWORLD_ZIM_MODEL_PATH": str(Path(model_root) / "zim-anything-vitl"),
+        "HYWORLD_GROUNDING_DINO_MODEL_PATH": str(Path(model_root) / "grounding-dino-tiny"),
+        "HYWORLD_SAM3_MODEL_PATH": str(Path(model_root) / "sam3"),
+        "HYWORLD_WORLDSTEREO_PATH": str(Path(model_root) / "WorldStereo"),
+    },
+    "import_checks": {
+        "dataevolver": ["torch", "diffsynth.pipelines.qwen_image", "transformers"],
+        "hyworld": ["torch", "moge.model.v2", "hyworld2.worldrecon.pipeline", "gsplat"],
+    },
+    "workers": [
+        {"name": "stage2-qwen-image", "kind": "stage2", "python": "dataevolver_python", "device": "cuda:0", "model_path": str(Path(model_root) / "Qwen-Image-2512")},
+        {"name": "stage3-hunyuan", "kind": "stage3", "python": "dataevolver_python", "device": "cuda:1"},
+    ],
+    "health_endpoints": [],
+    }
+(out / "production_profile.json").write_text(
+    json.dumps(production_profile, indent=2, ensure_ascii=False) + "\n",
+    encoding="utf-8",
+)
+
+model_rows = "\n".join(
+    f"- {m['role']}: {m['name']} -> `{m['target_path']}` ({m['status']}, gated/access: {m['gated_or_access_dependent']})"
+    for m in models
+) or "- No default model downloads planned for this profile."
+
+missing_tools = []
+if tooling_status["python3"]["status"] == "missing" and tooling_status["python"]["status"] == "missing":
+    missing_tools.append("python3/python")
+if profile == "blender_mcp":
+    if not (shutil.which("ssh") or shutil.which("ssh.exe")):
+        missing_tools.append("ssh/ssh.exe")
+else:
+    for name in ["git", "curl", "uv", "uvx", "conda", "hf", "nvidia-smi", "blender"]:
+        if tooling_status[name]["status"] == "missing":
+            missing_tools.append(name)
+missing_tool_rows = "\n".join(f"- {name}: missing" for name in missing_tools) or "- None detected on the dry-run host."
+
+access_rows = "\n".join(
+    f"- {item['name']}: `{item['hf_repo']}` ({item['requirement']})"
+    for item in access_requirements
+) or "- No gated/access-dependent model repos in this profile."
+
+override_rows = "\n".join(
+    f"- `{item['file']}`: `{item['constant']}` should read `{item['env']}`"
+    for item in path_override_plan
+)
+if profile == "blender_mcp":
+    override_rows = "- None. Blender MCP does not change production pipeline path overrides or Stage 4 rendering."
+
+next_action_rows = "\n".join(f"- {item}" for item in next_actions)
+
+if profile == "blender_mcp":
+    blender_mcp_section = f"""## Blender MCP Operator
+
+This profile configures an optional operator/debug control plane for remote Blender. It is for scene inspection, viewport screenshots, temporary Blender Python execution, and fast lighting/camera/material experiments. It does not replace production Stage 4 rendering.
+
+Connection mode: `ssh_stdio`
+
+- SSH alias: `{blender_mcp_operator['ssh_alias']}`
+- Remote root: `{blender_mcp_operator['remote_root']}`
+- Remote Blender: `{blender_mcp_operator['remote_blender_bin']}`
+- Remote addon dir: `{blender_mcp_operator['remote_addon_dir']}`
+- Remote port: `{blender_mcp_operator['remote_port']}`
+- Remote uvx: `{blender_mcp_operator['remote_uvx']}`
+- tmux session: `{blender_mcp_operator['tmux_session']}`
+
+Preflight commands:
+
+```bash
+ssh {shlex.quote(blender_mcp_operator['ssh_alias'])} "command -v uvx; command -v xvfb-run; command -v tmux; test -x {shlex.quote(blender_mcp_operator['remote_blender_bin'])}"
+```
+
+Start the remote addon after preflight:
+
+```bash
+source .dataevolver/local/env.sh.example
+bash scripts/setup_blender_mcp_remote.sh start
+bash scripts/setup_blender_mcp_remote.sh status
+```
+
+Validate the remote addon socket:
+
+```bash
+ssh {shlex.quote(blender_mcp_operator['ssh_alias'])} 'python3 - <<PY
+import json, socket
+s=socket.socket(); s.settimeout(10)
+s.connect(("127.0.0.1",{blender_mcp_operator['remote_port']}))
+s.sendall(json.dumps({{"type":"get_scene_info","params":{{}}}}).encode())
+print(s.recv(2000).decode("utf-8", "replace"))
+PY'
+```
+
+Copy `.dataevolver/local/blender_mcp.codex.toml` into the user's Codex config, then restart Codex.
+
+Common failures:
+
+- `blender -b` cannot run the MCP addon because Blender timers do not execute command callbacks in background mode.
+- Missing `xvfb-run`, `libSM`, `libICE`, or `libEGL` prevents headless GUI Blender startup.
+- Multiple MCP clients connected to the same addon can make behavior confusing; keep one active Codex/Blender MCP client.
+"""
+else:
+    blender_mcp_section = ""
+
+if profile == "blender_mcp":
+    dependency_heading = "Blender MCP Remote Dependency Plan"
+    dependency_plan = f"""Remote Blender MCP needs a non-background Blender process and an MCP server launched through remote `uvx`.
+
+Required remote commands/packages:
+
+- `{blender_mcp_operator['remote_uvx']}`
+- `xvfb-run`
+- `tmux`
+- an executable Blender binary at `{blender_mcp_operator['remote_blender_bin']}`
+
+On Ubuntu headless servers, typical GUI/Xvfb packages are:
+
+```bash
+apt-get install -y xvfb libsm6 libice6 libxrender1 libxext6 libegl1 libgl1 libgles2 libxfixes3 libxi6 libxrandr2 libxcursor1 libxinerama1 libxxf86vm1
+```
+"""
+    handoff_heading = "Codex Config Handoff"
+    handoff_plan = """Review `.dataevolver/local/blender_mcp.codex.toml`, copy the snippet into the user's Codex config, then restart Codex. The bootstrap does not write global Codex config automatically."""
+    smoke_heading = "Blender MCP Smoke Tests"
+    smoke_plan = f"""Run these after remote preflight and addon startup:
+
+```bash
+bash scripts/setup_blender_mcp_remote.sh status
+ssh {shlex.quote(blender_mcp_operator['ssh_alias'])} 'python3 - <<PY
+import json, socket
+s=socket.socket(); s.settimeout(10)
+s.connect(("127.0.0.1",{blender_mcp_operator['remote_port']}))
+s.sendall(json.dumps({{"type":"get_scene_info","params":{{}}}}).encode())
+print(s.recv(2000).decode("utf-8", "replace"))
+PY'
+timeout 12s ssh {shlex.quote(blender_mcp_operator['ssh_alias'])} 'env BLENDER_HOST=127.0.0.1 BLENDER_PORT={blender_mcp_operator['remote_port']} {shlex.quote(blender_mcp_operator['remote_uvx'])} --python 3.11 blender-mcp'
+```
+"""
+    start_heading = "Operator Start"
+    start_plan = """```bash
+source .dataevolver/local/env.sh.example
+bash scripts/setup_blender_mcp_remote.sh start
+bash scripts/setup_blender_mcp_remote.sh status
+```
+"""
+else:
+    dependency_heading = "Production Dependency Plan"
+    dependency_plan = """Use `uv venv .venv --python 3.10 --system-site-packages` first on shared GPU servers so a validated system NVIDIA PyTorch build can be reused. Install the CUDA wheel only when `import torch` fails inside the venv or reports no usable CUDA.
+
+Runtime pins from production validation:
+
+- `numpy<2`
+- `tokenizers==0.22.1`
+- SAM3 extras: `iopath`, `timm`, `ftfy`
+- Hunyuan paint/native build: `uv pip install --no-build-isolation -e "$HUNYUAN3D_REPO/hy3dpaint/custom_rasterizer"` after CUDA/nvcc preflight
+- DifferentiableRenderer: compile only after CUDA/nvcc compatibility is confirmed"""
+
+    handoff_heading = "Source and Weight Path Separation"
+    handoff_plan = """Keep code and weights separate:
+
+- `SAM3_CKPT` points to `sam3.pt`.
+- `SAM3_DIR` points to the SAM3 source checkout or importable package.
+- `HUNYUAN3D_REPO` points to the Tencent-Hunyuan/Hunyuan3D-2.1 source checkout.
+- `MODEL_HUB` and `PAINT_MODEL_HUB` point to Hunyuan3D weight directories."""
+
+    smoke_heading = "Production Smoke Tests"
+    smoke_plan = """Production readiness smoke order:
+
+1. Preflight: Python, uv, GPU, disk, Blender, and model paths.
+2. Import smoke: torch CUDA/bf16, Qwen image dependencies, SAM3, Hunyuan shape/paint, transformers, and telemetry packages.
+3. Runtime smoke: Stage 2 -> Stage 2.5 -> Stage 3 shape-only -> Stage 3 textured -> Stage 5.5 VLM loader.
+4. Stage 3 textured smoke should write to a local smoke directory such as `.dataevolver/local/smoke/meshes_textured` and use bounded paint controls such as `--paint-max-faces 5000 --paint-remesh-modes false --paint-attempt-timeout-sec 300`.
+5. After the agent records the smoke evidence in the deployment note, delete generated smoke artifacts with `rm -rf .dataevolver/local/smoke` so the working directory stays clean.
+
+`--shape-only` is a fallback for missing DINO, RealESRGAN, or paint extensions; it is not a full textured production-readiness check."""
+    start_heading = "Production Start"
+    start_plan = """```bash
+source .dataevolver/local/env.sh.example
+python scripts/dataevolver_production.py doctor --profile .dataevolver/local/production_profile.json
+python scripts/dataevolver_production.py start --profile .dataevolver/local/production_profile.json
+```
+"""
+
+(out / "ENVIRONMENT.md").write_text(
+    f"""# DataEvolver Local Environment
+
+Generated by `scripts/bootstrap_dataevolver_default.sh` in dry-run mode. {"This operator profile configures Blender MCP only and does not launch production workers." if profile == "blender_mcp" else "The generated production profile is executable only after all paths pass the production doctor."}
+
+## Summary
+
+- Profile: `{profile}`
+- Target workflow: `{target_workflow}`
+- Workspace root: `{workspace_root}`
+- Model root: `{model_root}`
+- Python backend preference: `{python_backend}`
+- Install policy: dry-run only; no real install or model download has been performed.
+
+## Models
+
+{model_rows}
+
+## Preflight Gaps
+
+{missing_tool_rows}
+
+## Hugging Face Access
+
+{access_rows}
+
+{blender_mcp_section}
+
+## V1 Path Overrides
+
+{override_rows}
+
+## {dependency_heading}
+
+{dependency_plan}
+
+## {handoff_heading}
+
+{handoff_plan}
+
+## {smoke_heading}
+
+{smoke_plan}
+
+## {start_heading}
+
+{start_plan}
+
+## Next Actions
+
+{next_action_rows}
+""",
+    encoding="utf-8",
+)
+
+env_lines = [
+    "# Source this file after reviewing paths. It intentionally contains no tokens.",
+    f"export DATAEVOLVER_WORKSPACE_ROOT={shlex.quote(workspace_root)}",
+    f"export DATAEVOLVER_MODEL_ROOT={shlex.quote(model_root)}",
+    f"export BLENDER_BIN={shlex.quote(shutil.which('blender') or '/path/to/blender')}",
+    f"export DATAEVOLVER_PYTHON={shlex.quote(str(Path(workspace_root) / '.venv/bin/python'))}",
+    f"export HYWORLD_PYTHON={shlex.quote(str(Path(workspace_root) / '.venv-hyworld/bin/python'))}",
+    f"export DATAEVOLVER_PRODUCTION_PROFILE={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/production_profile.json'))}",
+]
+if profile == "blender_mcp":
+    env_lines.extend([
+        f"export DATAEVOLVER_BLENDER_MCP_REMOTE={shlex.quote(blender_mcp_operator['ssh_alias'])}",
+        f"export DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT={shlex.quote(blender_mcp_operator['remote_root'])}",
+        f"export DATAEVOLVER_REMOTE_BLENDER_BIN={shlex.quote(blender_mcp_operator['remote_blender_bin'])}",
+        f"export BLENDER_MCP_REMOTE_PORT={shlex.quote(str(blender_mcp_operator['remote_port']))}",
+        f"export BLENDER_MCP_REMOTE_UVX={shlex.quote(blender_mcp_operator['remote_uvx'])}",
+        f"export BLENDER_MCP_TMUX_SESSION={shlex.quote(blender_mcp_operator['tmux_session'])}",
+        f"export DATAEVOLVER_BLENDER_MCP_REMOTE_ADDON_DIR={shlex.quote(blender_mcp_operator['remote_addon_dir'])}",
+    ])
+for model in models:
+    env_name = model.get("env")
+    if not env_name:
+        continue
+    value = model["target_path"]
+    if env_name == "SAM3_CKPT":
+        value = str(Path(value) / "sam3.pt")
+    env_lines.append(f"export {env_name}={shlex.quote(value)}")
+if profile in {"default", "full"}:
+    if profile == "default":
+        env_lines.append(f"export QWEN_IMAGE_EDIT_MODEL_PATH={shlex.quote(str(Path(model_root) / 'Qwen-Image-Edit-2511'))}")
+    env_lines.append(f"export PAINT_MODEL_HUB={shlex.quote(str(Path(model_root) / 'Hunyuan3D-2.1'))}")
+    env_lines.append(f"export SAM3_DIR={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/vendor/sam3-src'))}")
+    env_lines.append(f"export HUNYUAN3D_REPO={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/vendor/Hunyuan3D-2.1-src'))}")
+    env_lines.append('export REALESRGAN_CKPT="$HUNYUAN3D_REPO/hy3dpaint/ckpt/RealESRGAN_x4plus.pth"')
+    env_lines.append(f"export HYWORLD_SRC={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/vendor/HY-World-2.0-src'))}")
+    env_lines.append(f"export HYWORLD_WEIGHTS={shlex.quote(str(Path(model_root) / 'HY-World-2.0'))}")
+    env_lines.append(f"export HYWORLD_MOGE_MODEL_PATH={shlex.quote(str(Path(model_root) / 'moge-2-vitl-normal'))}")
+    env_lines.append(f"export HYWORLD_ZIM_MODEL_PATH={shlex.quote(str(Path(model_root) / 'zim-anything-vitl'))}")
+    env_lines.append(f"export HYWORLD_GROUNDING_DINO_MODEL_PATH={shlex.quote(str(Path(model_root) / 'grounding-dino-tiny'))}")
+    env_lines.append(f"export HYWORLD_SAM3_MODEL_PATH={shlex.quote(str(Path(model_root) / 'sam3'))}")
+    env_lines.append(f"export HYWORLD_WORLDSTEREO_PATH={shlex.quote(str(Path(model_root) / 'WorldStereo'))}")
+    env_lines.append("export STAGE3_PAINT_MAX_FACES=5000")
+    env_lines.append("export STAGE3_PAINT_REMESH_MODES=false")
+    env_lines.append("export STAGE3_PAINT_ATTEMPT_TIMEOUT_SEC=300")
+if profile != "blender_mcp":
+    env_lines.append("# Set HF_TOKEN in your shell only when performing real downloads.")
+(out / "env.sh.example").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+
+if profile == "blender_mcp":
+    codex_args = [
+        blender_mcp_operator["ssh_alias"],
+        "env",
+        "BLENDER_HOST=127.0.0.1",
+        f"BLENDER_PORT={blender_mcp_operator['remote_port']}",
+        "UV_PYTHON_PREFERENCE=only-managed",
+        blender_mcp_operator["remote_uvx"],
+        "--python",
+        "3.11",
+        "blender-mcp",
+    ]
+    codex_toml = "\n".join([
+        f"[mcp_servers.{blender_mcp_operator['codex_mcp_server_name']}]",
+        'command = "ssh.exe"',
+        f"args = {json.dumps(codex_args, ensure_ascii=False)}",
+        "startup_timeout_sec = 30",
+        "tool_timeout_sec = 240",
+        "",
+    ])
+    (out / "blender_mcp.codex.toml").write_text(codex_toml, encoding="utf-8")
+
+print(f"[write-local-config] wrote {out / 'ENVIRONMENT.md'}")
+print(f"[write-local-config] wrote {out / 'env.config.json'}")
+print(f"[write-local-config] wrote {out / 'env.sh.example'}")
+print(f"[write-local-config] wrote {out / 'production_profile.json'}")
+if profile == "blender_mcp":
+    print(f"[write-local-config] wrote {out / 'blender_mcp.codex.toml'}")
+PY
+}
+
+print_probe_plan
+print_env_plan
+print_model_plan
+print_blender_mcp_plan
+print_config_plan
+
+if [[ "$WRITE_LOCAL_CONFIG" == "1" ]]; then
+  write_local_config
+else
+  section "write-local-config"
+  printf 'Skipped. Re-run with --write-local-config to write .dataevolver/local demo files.\n'
+fi
+
+section "done"
+printf 'Dry-run demo complete. No install, download, token write, or long-running job was performed.\n'

--- a/scripts/setup_blender_mcp_remote.sh
+++ b/scripts/setup_blender_mcp_remote.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SSH_BIN="${DATAEVOLVER_SSH_BIN:-ssh.exe}"
+SCP_BIN="${DATAEVOLVER_SCP_BIN:-scp.exe}"
+REMOTE="${DATAEVOLVER_BLENDER_MCP_REMOTE:-my-blender-server}"
+REMOTE_ROOT="${DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT:-${DATAEVOLVER_REMOTE_ROOT:-/path/to/DataEvolver}}"
+REMOTE_MCP_DIR="${DATAEVOLVER_BLENDER_MCP_REMOTE_ADDON_DIR:-${DATAEVOLVER_BLENDER_MCP_REMOTE_DIR:-$REMOTE_ROOT/.dataevolver/blender-mcp}}"
+REMOTE_BLENDER_BIN="${DATAEVOLVER_REMOTE_BLENDER_BIN:-/path/to/blender}"
+REMOTE_PORT="${BLENDER_MCP_REMOTE_PORT:-9876}"
+REMOTE_UVX="${BLENDER_MCP_REMOTE_UVX:-uvx}"
+LOCAL_PORT="${BLENDER_MCP_LOCAL_PORT:-9876}"
+TMUX_SESSION="${BLENDER_MCP_TMUX_SESSION:-dataevolver-blender-mcp}"
+REMOTE_LOG="${BLENDER_MCP_REMOTE_LOG:-$REMOTE_MCP_DIR/blender-mcp.log}"
+
+ADDON_SRC="$PROJECT_ROOT/external/blender-mcp/addon.py"
+BOOTSTRAP_SRC="$PROJECT_ROOT/scripts/blender_mcp_bootstrap.py"
+
+SCP_OPTS=()
+if [[ -n "${DATAEVOLVER_SCP_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  SCP_OPTS=(${DATAEVOLVER_SCP_OPTS})
+elif [[ "$SCP_BIN" == *.exe ]]; then
+  SCP_OPTS=(-O)
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/setup_blender_mcp_remote.sh <install|start|tunnel|status|stop|restart>
+
+Environment overrides:
+  DATAEVOLVER_SSH_BIN                 ssh.exe by default, useful from WSL
+  DATAEVOLVER_SCP_BIN                 scp.exe by default, useful from WSL
+  DATAEVOLVER_BLENDER_MCP_REMOTE      my-blender-server by default
+  DATAEVOLVER_BLENDER_MCP_REMOTE_ROOT remote DataEvolver checkout
+  DATAEVOLVER_BLENDER_MCP_REMOTE_ADDON_DIR remote addon/bootstrap directory
+  DATAEVOLVER_REMOTE_BLENDER_BIN      remote Blender executable
+  BLENDER_MCP_REMOTE_PORT             remote addon port, default 9876
+  BLENDER_MCP_REMOTE_UVX              remote uvx executable, default uvx
+  BLENDER_MCP_LOCAL_PORT              local forwarded port, default 9876
+  BLENDER_MCP_TMUX_SESSION            remote tmux session name
+  BLENDER_MCP_REMOTE_LOG              remote Blender stdout/stderr log
+
+Typical flow:
+  scripts/setup_blender_mcp_remote.sh install
+  scripts/setup_blender_mcp_remote.sh start
+  scripts/setup_blender_mcp_remote.sh tunnel
+EOF
+}
+
+remote_sh() {
+  "$SSH_BIN" "$REMOTE" "$@"
+}
+
+local_scp_path() {
+  if [[ "$SCP_BIN" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+    wslpath -w "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+install_remote() {
+  if [[ ! -f "$ADDON_SRC" ]]; then
+    echo "Missing $ADDON_SRC. Clone https://github.com/ahujasid/blender-mcp.git into external/blender-mcp first." >&2
+    exit 1
+  fi
+  remote_sh "mkdir -p '$REMOTE_MCP_DIR'"
+  "$SCP_BIN" "${SCP_OPTS[@]}" "$(local_scp_path "$ADDON_SRC")" "$(local_scp_path "$BOOTSTRAP_SRC")" "$REMOTE:$REMOTE_MCP_DIR/"
+  remote_sh "test -x '$REMOTE_BLENDER_BIN' && test -x '$REMOTE_UVX' && command -v xvfb-run >/dev/null && command -v tmux >/dev/null"
+  echo "Installed Blender MCP addon files to $REMOTE:$REMOTE_MCP_DIR"
+}
+
+start_remote() {
+  install_remote
+  remote_sh "tmux has-session -t '$TMUX_SESSION' 2>/dev/null && tmux kill-session -t '$TMUX_SESSION' || true"
+  remote_sh "cd '$REMOTE_ROOT' && : > '$REMOTE_LOG' && tmux new-session -d -s '$TMUX_SESSION' 'mkdir -p /tmp/runtime-root && chmod 700 /tmp/runtime-root && XDG_RUNTIME_DIR=/tmp/runtime-root GDK_BACKEND=x11 WAYLAND_DISPLAY= BLENDER_MCP_ADDON=\"$REMOTE_MCP_DIR/addon.py\" BLENDER_MCP_PORT=\"$REMOTE_PORT\" xvfb-run -a \"$REMOTE_BLENDER_BIN\" --python \"$REMOTE_MCP_DIR/blender_mcp_bootstrap.py\" >> \"$REMOTE_LOG\" 2>&1'"
+  echo "Started remote Blender MCP tmux session: $TMUX_SESSION"
+}
+
+tunnel_local() {
+  echo "Forwarding 127.0.0.1:$LOCAL_PORT -> $REMOTE:127.0.0.1:$REMOTE_PORT"
+  exec "$SSH_BIN" -N -L "127.0.0.1:$LOCAL_PORT:127.0.0.1:$REMOTE_PORT" "$REMOTE"
+}
+
+status_remote() {
+  remote_sh "printf 'tmux: '; tmux has-session -t '$TMUX_SESSION' 2>/dev/null && printf 'running\n' || printf 'stopped\n'; printf 'port: '; (ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null || true) | grep ':$REMOTE_PORT ' || true; pgrep -af 'blender.*blender_mcp_bootstrap|Blender MCP' || true; printf 'log: $REMOTE_LOG\n'; tail -40 '$REMOTE_LOG' 2>/dev/null || true"
+}
+
+stop_remote() {
+  remote_sh "tmux has-session -t '$TMUX_SESSION' 2>/dev/null && tmux kill-session -t '$TMUX_SESSION' || true"
+  echo "Stopped remote Blender MCP tmux session if it existed: $TMUX_SESSION"
+}
+
+case "${1:-}" in
+  install) install_remote ;;
+  start) start_remote ;;
+  tunnel) tunnel_local ;;
+  status) status_remote ;;
+  stop) stop_remote ;;
+  restart) stop_remote; start_remote ;;
+  *) usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Add a dry-run onboarding path for configuring Blender MCP as an optional DataEvolver operator/debug tool. The new `blender_mcp` profile generates local non-secret environment files, a Codex MCP config snippet, and remote Blender preflight/start instructions without installing dependencies, downloading models, editing global Codex config, or launching remote Blender.

## 摘要

新增一个 dry-run onboarding 路径，用于把 Blender MCP 配置为可选的 DataEvolver operator/debug 工具。新的 `blender_mcp` profile 会生成本地非敏感环境文件、Codex MCP 配置片段，以及远端 Blender 预检/启动说明；不会安装依赖、下载模型、修改全局 Codex 配置或启动远端 Blender。

## Changes

- Add `--profile blender_mcp` to `scripts/bootstrap_dataevolver_default.sh` with `target_workflow=operator_blender_mcp`.
- Generate `operators.blender_mcp` in `.dataevolver/local/env.config.json` and `.dataevolver/local/blender_mcp.codex.toml` for SSH stdio MCP configuration.
- Add remote Blender MCP helper scripts for Xvfb-based addon startup and status/stop/tunnel operations.
- Document the setup in `docs/BLENDER_MCP_REMOTE.md` and link the dry-run command from README / README_zh.
- Keep Blender MCP explicitly separate from production Stage 4 rendering and `BLENDER_BIN` pipeline execution.
- Use placeholder remote host/path defaults so lab hostnames, private mount points, and local test paths are not committed.

## 变更

- 在 `scripts/bootstrap_dataevolver_default.sh` 中新增 `--profile blender_mcp`，并设置 `target_workflow=operator_blender_mcp`。
- 在 `.dataevolver/local/env.config.json` 和 `.dataevolver/local/blender_mcp.codex.toml` 中生成 `operators.blender_mcp`，用于 SSH stdio MCP 配置。
- 新增远端 Blender MCP 辅助脚本，支持基于 Xvfb 的 addon 启动以及 status/stop/tunnel 操作。
- 在 `docs/BLENDER_MCP_REMOTE.md` 中记录配置流程，并从 README / README_zh 链接 dry-run 命令。
- 明确 Blender MCP 与生产 Stage 4 渲染、`BLENDER_BIN` pipeline 执行保持分离。
- 默认远端主机和路径使用占位符，避免提交实验室主机名、私有挂载点和本地测试路径。

## Validation

- `git diff --check origin/codex/t2iblenderedit...HEAD -- <PR files>`
- `bash -n scripts/bootstrap_dataevolver_default.sh`
- `bash -n scripts/setup_blender_mcp_remote.sh`
- `python3 -m py_compile scripts/blender_mcp_bootstrap.py`
- `bash scripts/bootstrap_dataevolver_default.sh --profile blender_mcp --dry-run --write-local-config`
- JSON validation for generated `.dataevolver/local/env.config.json`
- TOML validation for generated `.dataevolver/local/blender_mcp.codex.toml`
- PR diff scan for lab hostnames, private mount paths, local drive paths, and credential-looking assignments

## 验证

- `git diff --check origin/codex/t2iblenderedit...HEAD -- <PR files>`
- `bash -n scripts/bootstrap_dataevolver_default.sh`
- `bash -n scripts/setup_blender_mcp_remote.sh`
- `python3 -m py_compile scripts/blender_mcp_bootstrap.py`
- `bash scripts/bootstrap_dataevolver_default.sh --profile blender_mcp --dry-run --write-local-config`
- 校验生成的 `.dataevolver/local/env.config.json` 可被 JSON 解析
- 校验生成的 `.dataevolver/local/blender_mcp.codex.toml` 可被 TOML 解析
- 扫描 PR diff，检查实验室主机名、私有挂载路径、本地盘符路径和疑似凭据赋值

## Notes

Remote smoke was not run in this PR because the current environment does not have a confirmed reachable remote Blender host for the generic placeholder configuration. `graphify update .` is also blocked by the existing local `permission denied: graphify` issue.

## 说明

本 PR 未运行远端 smoke，因为当前环境没有针对通用占位符配置确认可连通的远端 Blender 主机。`graphify update .` 仍受当前本地 `permission denied: graphify` 问题阻塞。