### PR TITLE
[codex] Update onboarding GPU dry-run policy

### DIFF
--- a/.agents/skills/dataevolver-onboarding/SKILL.md
+++ b/.agents/skills/dataevolver-onboarding/SKILL.md
@@ -1,48 +1,82 @@
 ---
 name: dataevolver-onboarding
-description: Guide a lightweight DataEvolver setup interview and dry-run deployment handoff. Use when a user wants quick DataEvolver onboarding, server/environment discovery, default or custom model setup planning, Hugging Face token-safe download planning, or generation of local ENVIRONMENT.md and env.config.json setup profiles.
+description: Guide DataEvolver server setup and safe dry-run onboarding. Use when a user wants a Codex or Claude Code agent to configure a local or remote DataEvolver checkout, interview for SSH/runtime paths, inspect Python/uv/conda/Hugging Face/Blender/GPU readiness, plan dependency and model setup, choose a dynamic or fixed GPU shard policy, prepare HYWorld or paper-validation execution handoff, or generate non-sensitive .dataevolver/local/ENVIRONMENT.md and env.config.json profiles without launching long jobs.
 ---
 
 # DataEvolver Onboarding
 
-Use this skill to help a user quickly become ready to run DataEvolver without overwhelming them with the full environment surface. Keep the first pass light: interview, write a local profile, and hand off a dry-run deployment plan. Do not store secrets.
+Use this skill as the standard first step when an agent takes over a DataEvolver environment. Keep the first pass bounded: interview, inspect, write non-sensitive setup profiles when requested, and hand off a dry-run execution plan. Do not store secrets or start heavy jobs from this skill.
 
 ## Workflow
 
-1. Ask at most five setup questions:
-   - Target route: `quick_demo`, `t2i`, `edit`, `t2v`, `blender_3d`, `vlm_review`, `full_pipeline`, `world_model_scene`, or `custom`.
+1. Ask at most five base setup questions:
+   - Target route: `quick_demo`, `t2i`, `edit`, `t2v`, `blender_3d`, `vlm_review`, `full_pipeline`, `world_model_scene`, `paper_validation`, or `custom`.
    - Runtime location: local Linux path, remote SSH alias plus project path, or not cloned yet.
-   - Install policy: inspect only, generate plan, install Python deps, download models, or full setup later.
+   - Install policy: inspect only, generate plan, install Python deps later, download models later, or full setup later.
    - Model strategy: default DataEvolver models, existing paths, custom replacement models, or skip for now.
-   - Work/output paths: default `runtime/`, user path, or remote path.
-2. Do not ask tool-version questions in the interview. Let the demo script probe Python, `uv`, `uvx`, `conda`, `hf`, GPU, and Blender availability.
-3. Summarize known values, missing blockers, and the selected profile: `quick`, `default`, `full`, `world_model`, or `custom`.
-4. Generate or update `.dataevolver/local/ENVIRONMENT.md` and `.dataevolver/local/env.config.json` only when the user asks to save the profile.
-5. Hand off to the main agent with the package install and demo command:
-   `python -m pip install -e .`
-   `bash src/dataevolver/cli/bootstrap_dataevolver_default.sh --profile <profile> --dry-run --write-local-config`
-6. Tell the user that v0 is dry-run only: it prints install/download/config plans but does not install dependencies, download model weights, or launch long jobs.
+   - Work/output paths: default `.dataevolver/`, user path, or remote path.
+2. For `world_model_scene` or `paper_validation`, ask only the GPU follow-up values that are missing:
+   - GPU policy: `inspect_only`, `dynamic_backfill`, or `fixed_range`.
+   - Included GPUs, for example `all` or a user-provided GPU range.
+   - Reserved GPUs, for example a user-provided GPU range that hosts VLM/vLLM or another service.
+3. Let the dry-run script probe tool versions and paths. Do not ask tool-version questions manually.
+4. Summarize known values, blockers, selected profile, GPU policy, and whether the run is paper validation.
+5. Generate or update `.dataevolver/local/ENVIRONMENT.md` and `.dataevolver/local/env.config.json` only when the user asks to save the profile.
+6. Hand off with:
+   ```bash
+   python -m pip install -e .
+   bash src/dataevolver/cli/bootstrap_dataevolver_default.sh --profile <profile> --dry-run --write-local-config
+   ```
+   For HYWorld or paper validation, add `--profile world_model --gpu-policy <policy> --include-gpus <user-gpu-spec>` and, only if the user has service GPUs to protect, `--reserve-gpus <user-reserve-spec>`. Add `--paper-validation` when applicable.
+7. State explicitly that onboarding is dry-run only: it may print install/download/config/GPU shard plans, but it must not install dependencies, download weights, kill services, or launch long GPU jobs without explicit confirmation in the main conversation.
 
 ## Profiles
 
 - `quick`: environment probes and a dry-run route only.
 - `default`: current core pipeline defaults: Qwen-Image-2512, SAM3, Hunyuan3D-2.1, DINOv2 Giant, Qwen3.5-35B-A3B, and Blender.
 - `full`: `default` plus Qwen-Image-Edit-2511 and Wan2.1-T2V.
-- `world_model`: optional HYWorld / WorldMirror scene reconstruction route. Use only when the target route is `world_model_scene`; it adds HY-World-2.0, MoGe, ZIM, GroundingDINO, SAM3, WorldStereo, Wan I2V base, and WorldMirror/3DGS checks.
+- `world_model`: optional HYWorld / WorldMirror scene reconstruction route. Use only when the target route is `world_model_scene` or `paper_validation`; it adds HY-World-2.0, MoGe, ZIM, GroundingDINO, SAM3, WorldStereo, Wan I2V base, and WorldMirror/3DGS checks.
 - `custom`: record user-supplied model replacements as `needs_check`; do not perform compatibility review during onboarding.
 
-Do not put world-model setup into `default`. When a user wants standard DataEvolver generation, keep `default` focused on the core pipeline. When a user wants input image -> HY-Pano -> WorldMirror/metric depth mesh -> Blender scene contract -> multi-view validation -> object insertion -> final report, select route `world_model_scene` and profile `world_model`.
+Do not put world-model setup into `default`. When a user wants input image -> HY-Pano -> WorldMirror/metric depth mesh -> Blender scene contract -> multi-view validation -> object insertion -> final report, select route `world_model_scene` and profile `world_model`.
+
+## GPU Policy
+
+- `inspect_only`: inspect and report GPU inventory, memory, utilization, and obvious service processes; do not propose leases.
+- `dynamic_backfill`: recommended after target-host inspection for multi-GPU inference/rendering runs. Use `src/dataevolver/runtime/gpu_scheduler.py` to plan one scheduling cycle from current `nvidia-smi` state and pending independent shards.
+- `fixed_range`: restrict planning to user-provided `include_gpus` and `reserve_gpus`; use this when the user has pre-allocated cards or wants to protect a service card.
+
+Follow these scheduling rules:
+
+- Treat each independent inference, reconstruction, render, review, SR, or audit shard as an isolated process with an exclusive `CUDA_VISIBLE_DEVICES` lease unless it is CPU-only or an already-running service request.
+- Poll `nvidia-smi` before each scheduling cycle. Reserve GPUs that are explicitly reserved, high-memory busy, high-utilization busy, or known to host vLLM/VLM/model services.
+- Do not blindly use all GPUs for HYWorld pano/worldgen. Keep fragile high-memory or distributed stages on their smallest stable GPU set, then backfill idle GPUs with Blender render shards, scene-view gates, rotation8 shards, SR/contact-sheet batches, VLM service requests, and CPU/file audits.
+- For NCCL/process-group failures, do not increase `nproc` blindly. First verify one process per GPU, clean `MASTER_ADDR`/`MASTER_PORT`/rank environment, unique rendezvous files, and consistent collective ordering.
+- Preserve failed shard logs and outputs as evidence. For paper validation, failure samples are part of the report and must not be silently replaced.
+
+## Environment Plan
+
+- Prefer:
+  ```bash
+  uv venv .venv --python 3.10 --system-site-packages
+  source .venv/bin/activate
+  python -m pip install -e .
+  ```
+- Install `python -m pip install -e ".[hyworld]"` only for `world_model_scene` or paper-validation routes. The extra covers pip-managed packages, not model weights, source checkouts, Blender, or CUDA/native extension builds.
+- Install SAM3, Hunyuan3D, HYWorld, CUDA/C++ extensions, and model weights only after target-host preflight confirms Python, CUDA/PyTorch ABI, `nvcc`, disk space, and source/weight paths.
+- Reuse a validated system CUDA PyTorch through `--system-site-packages` when possible; install a CUDA wheel only if `import torch` fails or reports no usable CUDA.
 
 ## Safety Rules
 
-- Never write Hugging Face, OpenAI, Anthropic, SSH, cookie, or API tokens to project files.
+- Never write Hugging Face, OpenAI, Anthropic, SSH, cookie, API, or service tokens to project files.
 - Mention `HF_TOKEN` only as a shell environment variable for future real downloads.
 - Treat SAM3 and other gated models as access-dependent; ask the user to obtain access instead of trying to bypass it.
-- Treat missing `uv`, `uvx`, `conda`, `hf`, `nvidia-smi`, or `blender` as non-blocking in v0. Surface them as next actions for real setup.
+- Treat missing `uv`, `uvx`, `conda`, `hf`, `nvidia-smi`, or `blender` as non-blocking in dry-run. Surface them as next actions for real setup.
 - Do not modify `CLAUDE.md`; the main agent may decide later whether to sync selected non-sensitive facts.
-- If the user asks for real installation or real downloads, first use the demo script output as the plan and ask for explicit confirmation in the main conversation.
-- Prefer `uvx --from huggingface_hub hf download ...` for printed Hugging Face download plans, with `hf download ...` as fallback. Do not execute either command in v0.
-- Use `python -m pip install -e ".[hyworld]"` only for the optional `world_model_scene` route; keep the default install lightweight. The extra covers pip-managed packages, not model weights, source checkouts, Blender, or CUDA/native extension builds.
+- Do not commit user-specific GPU choices such as concrete card ranges, service reservations, or host process state to the public repo. Store them only in ignored `.dataevolver/local/` profiles or user memory.
+- Do not kill existing vLLM/VLM services during onboarding. Record them as reservations unless the user explicitly authorizes restart outside the dry-run flow.
+- If the user asks for real installation, downloads, service restarts, or GPU execution, first use the dry-run output as the plan and ask for explicit confirmation.
+- Prefer `uvx --from huggingface_hub hf download ...` for printed Hugging Face download plans, with `hf download ...` as fallback. Do not execute either command in dry-run.
 
 ## Known V1 Requirements
 
@@ -50,28 +84,33 @@ Do not put world-model setup into `default`. When a user wants standard DataEvol
   `QWEN_IMAGE_MODEL_PATH`, `SAM3_CKPT`, `SAM3_DIR`, `HUNYUAN3D_REPO`, `MODEL_HUB`, `PAINT_MODEL_HUB`, `DINO_MODEL_PATH`, `REALESRGAN_CKPT`, and `VLM_MODEL_PATH`.
 - For `world_model_scene`, also source or export:
   `HYWORLD_SRC`, `HYWORLD_WEIGHTS`, `HYWORLD_PYTHON`, `HYWORLD_MOGE_MODEL_PATH`, `HYWORLD_ZIM_MODEL_PATH`, `HYWORLD_GROUNDING_DINO_MODEL_PATH`, `HYWORLD_SAM3_MODEL_PATH`, `HYWORLD_WORLDSTEREO_PATH`, `HYWORLD_WAN_BASE_MODEL`, and `WORLDSTEREO_BASE_MODEL_PATH`.
-- For `world_model_scene`, treat a VLM pass as advisory only. Review evidence should come from the HYWorld scene contract, multi-view pure-scene renders, manifest/lineage hashes, and the final scene/object report.
+- For paper validation, require `timing_ledger.json`, `gpu_shards.json`, `RUN_STATE.json`, source/image/GLB/final-output manifests, failure evidence, and quality reports before calling the run complete.
+- Treat VLM scores as auxiliary. Completion evidence must come from source paths, hashes, scene contracts, pure-scene renders, per-angle masks/bboxes/visibility, and final manifests.
 - Install SAM3 and Hunyuan3D repo-specific dependencies only after target-host preflight.
 - Compile Hunyuan3D CUDA/C++ extensions only after CUDA/nvcc compatibility is confirmed.
 
 ## Local Profile Contents
 
-`ENVIRONMENT.md` should be human-readable and include:
+`ENVIRONMENT.md` should include:
 
-- Selected profile and target workflow.
-- Runtime location and workspace/model roots.
-- Install policy.
+- Selected profile, target workflow, and whether this is paper validation.
+- Runtime location, workspace/model roots, and work/output paths.
+- Install policy and dependency plan.
 - Model choices and missing values.
-- Tooling status and missing commands.
+- Tooling status, server preflight summary, and missing commands.
+- GPU policy, included/reserved GPUs, and dry-run GPU shard plan.
 - Hugging Face gated/access-dependent repos.
 - Runtime path override plan for v1.
+- Timing/GPU/failure ledger requirements when applicable.
 - Next actions for the main agent.
 
 `env.config.json` should include:
 
 - `profile`, `target_workflow`, `runtime_location`, `install_policy`
 - `model_root`, `workspace_root`
-- `tooling_status`, `models`, `custom_models`, `access_requirements`
+- `tooling_status`, `server_preflight`, `models`, `custom_models`, `access_requirements`
+- `gpu_policy`, `include_gpus`, `reserve_gpus`, `gpu_plan`
+- `execution_mode`, `paper_validation`, `ledger_requirements`
 - `path_override_plan`, `v1_blockers`, `next_actions`, `generated_at`
 
 Keep both files concise. Use `unknown`, `not_requested`, or `needs_check` instead of blocking onboarding when the user is unsure.

--- a/.agents/skills/dataevolver-onboarding/agents/openai.yaml
+++ b/.agents/skills/dataevolver-onboarding/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "DataEvolver Onboarding"
-  short_description: "Quick dry-run DataEvolver setup profiles"
-  default_prompt: "Use $dataevolver-onboarding to create a quick dry-run setup profile for DataEvolver."
+  short_description: "Server, uv, and GPU dry-run setup"
+  default_prompt: "Use $dataevolver-onboarding to inspect my DataEvolver server, choose a GPU policy, and write a dry-run setup profile."

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ The core innovation: a **goal-driven loop agent** that iteratively improves rend
 ## Quick Start
 
 Start with the lightweight onboarding dry-run. It checks the shape of your
-environment, prints the setup and model download plan, and writes local
+environment, prints the setup, model download, and GPU policy plan, and writes local
 non-sensitive config files. It does **not** install dependencies, download model
-weights, write tokens, or launch GPU jobs.
+weights, write tokens, kill services, or launch GPU jobs.
 
 ### 1. Clone the repository
 
@@ -146,11 +146,34 @@ bash src/dataevolver/cli/bootstrap_dataevolver_default.sh \
   --write-local-config
 ```
 
-The script prints four sections:
+For HYWorld / WorldMirror or paper-validation runs, add an explicit GPU policy
+so the first dry-run records how future agents should inspect or reserve GPUs:
+
+```bash
+bash src/dataevolver/cli/bootstrap_dataevolver_default.sh \
+  --profile world_model \
+  --model-root /path/to/dataevolver-models \
+  --workspace-root "$PWD" \
+  --gpu-policy inspect_only \
+  --include-gpus all \
+  --paper-validation \
+  --dry-run \
+  --write-local-config
+```
+
+After inspecting the target host, rerun with a user-chosen policy such as
+`--gpu-policy dynamic_backfill` or `--gpu-policy fixed_range`. If a GPU is
+already serving vLLM, VLM review, or another service, add
+`--reserve-gpus <user-reserved-gpu-spec>` for that host. Do not commit concrete
+host-specific GPU ranges or policy choices to the public repository; they belong
+in ignored `.dataevolver/local/` profiles.
+
+The script prints five sections:
 
 | Section | What it tells you |
 |---------|-------------------|
 | `preflight` | Linux, GPU, Python, `uv`/`conda`, Blender, and Hugging Face CLI availability |
+| `gpu plan` | Inspect-only, dynamic backfill, or fixed-range GPU planning for future shards |
 | `env plan` | The preferred `uv` environment plan and `conda` fallback |
 | `model plan` | Hugging Face repos, target paths, gated-access notes, and printed download commands |
 | `config plan` | Non-sensitive environment variables that the pipeline can read |
@@ -175,9 +198,11 @@ When `--write-local-config` is used, the generated local files are:
 OpenAI, SSH, cookie, or API tokens in these files.
 
 If you are working with an agent environment that supports skills, ask it to use
-the `dataevolver-onboarding` skill. It should interview you for only five setup
+the `dataevolver-onboarding` skill. It should interview you for five setup
 areas: target route, runtime location, install policy, model strategy, and
-workspace/output paths, then run the dry-run script above.
+workspace/output paths. For HYWorld or paper-validation routes, it should also
+record the GPU policy (`inspect_only`, `dynamic_backfill`, or `fixed_range`),
+included GPUs, and reserved GPUs before running the dry-run script above.
 
 ### 4. Production Setup
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -100,8 +100,8 @@ DataEvolver 将合成数据构建转化为一个 **目标驱动的优化闭环**
 ## 快速开始
 
 建议先从轻量 onboarding dry-run 开始。它会检查你的环境形态，打印安装、
-模型下载和配置写入计划，并在需要时生成本地非敏感配置文件。它**不会**
-安装依赖、下载模型权重、写入 token，或启动 GPU 长任务。
+模型下载、GPU 策略和配置写入计划，并在需要时生成本地非敏感配置文件。
+它**不会**安装依赖、下载模型权重、写入 token、kill 服务，或启动 GPU 长任务。
 
 ### 1. 克隆仓库
 
@@ -144,11 +144,33 @@ bash src/dataevolver/cli/bootstrap_dataevolver_default.sh \
   --write-local-config
 ```
 
-脚本会输出四段内容：
+如果是 HYWorld / WorldMirror 或论文验证实验，首次 dry-run 先显式记录
+GPU 探测策略，便于后续 agent 按目标机器实际状态选择动态分片或保护服务卡：
+
+```bash
+bash src/dataevolver/cli/bootstrap_dataevolver_default.sh \
+  --profile world_model \
+  --model-root /path/to/dataevolver-models \
+  --workspace-root "$PWD" \
+  --gpu-policy inspect_only \
+  --include-gpus all \
+  --paper-validation \
+  --dry-run \
+  --write-local-config
+```
+
+完成目标机器探测后，再按用户选择改用 `--gpu-policy dynamic_backfill` 或
+`--gpu-policy fixed_range`。如果某张 GPU 已经在运行 vLLM、VLM review 或其他服务，
+按该机器实际情况追加 `--reserve-gpus <user-reserved-gpu-spec>`。不要把具体机器的
+GPU 范围、服务卡配置或策略选择提交到公共仓库；这些内容只应写入被忽略的
+`.dataevolver/local/` profile。
+
+脚本会输出五段内容：
 
 | 段落 | 说明 |
 |------|------|
 | `preflight` | Linux、GPU、Python、`uv`/`conda`、Blender、Hugging Face CLI 可用性 |
+| `gpu plan` | 面向后续 shard 的 inspect-only、dynamic backfill 或 fixed-range GPU 规划 |
 | `env plan` | 优先 `uv` 的环境计划，以及 `conda` fallback |
 | `model plan` | Hugging Face repo、目标路径、gated access 提示和打印出的下载命令 |
 | `config plan` | pipeline 可读取的非敏感环境变量 |
@@ -173,8 +195,10 @@ bash src/dataevolver/cli/bootstrap_dataevolver_default.sh \
 OpenAI、SSH、cookie 或 API token 写入这些文件。
 
 如果你在支持 skills 的 agent 环境中使用 DataEvolver，可以让 agent 使用
-`dataevolver-onboarding` skill。它应该只围绕五类信息进行访谈：目标路线、
-运行位置、安装策略、模型策略、工作/输出路径，然后运行上面的 dry-run 脚本。
+`dataevolver-onboarding` skill。它应该围绕五类基础信息进行访谈：目标路线、
+运行位置、安装策略、模型策略、工作/输出路径。若选择 HYWorld 或论文验证路线，
+还应记录 GPU 策略（`inspect_only`、`dynamic_backfill` 或 `fixed_range`）、
+可用 GPU 范围和保留 GPU，然后运行上面的 dry-run 脚本。
 
 ### 4. Production Setup（生产部署）
 

--- a/src/dataevolver/cli/bootstrap_dataevolver_default.sh
+++ b/src/dataevolver/cli/bootstrap_dataevolver_default.sh
@@ -9,6 +9,10 @@ WORKSPACE_ROOT="${DATAEVOLVER_WORKSPACE_ROOT:-${ROOT}}"
 PYTHON_BACKEND="auto"
 DRY_RUN=1
 WRITE_LOCAL_CONFIG=0
+GPU_POLICY="${DATAEVOLVER_GPU_POLICY:-inspect_only}"
+INCLUDE_GPUS="${DATAEVOLVER_INCLUDE_GPUS:-all}"
+RESERVE_GPUS="${DATAEVOLVER_RESERVE_GPUS:-}"
+PAPER_VALIDATION=0
 
 usage() {
   cat <<'USAGE'
@@ -25,6 +29,10 @@ Options:
   --model-root PATH            Target model root for the printed plan.
   --workspace-root PATH        DataEvolver checkout path for the printed plan.
   --python-backend auto|uv|conda
+  --gpu-policy inspect_only|dynamic_backfill|fixed_range
+  --include-gpus SPEC          User-provided GPU ids/ranges allowed for future shards.
+  --reserve-gpus SPEC          User-provided GPU ids/ranges reserved for existing services.
+  --paper-validation           Mark generated config as a paper-validation run.
   --write-local-config         Write .dataevolver/local demo profile files.
   -h, --help                   Show this help.
 USAGE
@@ -65,6 +73,25 @@ while [[ $# -gt 0 ]]; do
       PYTHON_BACKEND="$2"
       shift 2
       ;;
+    --gpu-policy)
+      [[ $# -ge 2 ]] || die "--gpu-policy requires a value"
+      GPU_POLICY="$2"
+      shift 2
+      ;;
+    --include-gpus)
+      [[ $# -ge 2 ]] || die "--include-gpus requires a value"
+      INCLUDE_GPUS="$2"
+      shift 2
+      ;;
+    --reserve-gpus)
+      [[ $# -ge 2 ]] || die "--reserve-gpus requires a value"
+      RESERVE_GPUS="$2"
+      shift 2
+      ;;
+    --paper-validation)
+      PAPER_VALIDATION=1
+      shift
+      ;;
     --write-local-config)
       WRITE_LOCAL_CONFIG=1
       shift
@@ -87,6 +114,11 @@ esac
 case "$PYTHON_BACKEND" in
   auto|uv|conda) ;;
   *) die "--python-backend must be one of: auto, uv, conda" ;;
+esac
+
+case "$GPU_POLICY" in
+  inspect_only|dynamic_backfill|fixed_range) ;;
+  *) die "--gpu-policy must be one of: inspect_only, dynamic_backfill, fixed_range" ;;
 esac
 
 if [[ "$DRY_RUN" != "1" ]]; then
@@ -161,6 +193,7 @@ print_probe_plan() {
   printf 'workspace_root: %s\n' "$WORKSPACE_ROOT"
   printf 'model_root: %s\n' "$MODEL_ROOT"
   printf 'python_backend: %s\n' "$PYTHON_BACKEND"
+  printf 'paper_validation: %s\n' "$PAPER_VALIDATION"
   printf '\nDetected commands:\n'
   for name in uname git curl python3 python uv uvx conda nvidia-smi blender hf; do
     cmd_status "$name"
@@ -174,6 +207,39 @@ print_probe_plan() {
   printf '  uvx --from huggingface_hub hf --help || hf --help\n'
   printf '  blender --version\n'
   printf '  hf auth whoami\n'
+}
+
+print_gpu_plan() {
+  section "gpu plan"
+  printf 'mode: dry-run only; no GPU lease or process launch will run\n'
+  printf 'gpu_policy: %s\n' "$GPU_POLICY"
+  printf 'include_gpus: %s\n' "$INCLUDE_GPUS"
+  printf 'reserve_gpus: %s\n' "${RESERVE_GPUS:-none}"
+  printf 'paper_validation: %s\n' "$PAPER_VALIDATION"
+  printf '\nGPU preflight commands to run on the target host before real work:\n'
+  printf '  nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu,uuid --format=csv\n'
+  printf '  nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv || true\n'
+  printf '  ps -eo pid,comm,args | grep -Ei "vllm|hyworld|blender|python" | head -n 80\n'
+  printf '\nScheduling guidance:\n'
+  case "$GPU_POLICY" in
+    inspect_only)
+      printf '  - Inspect and report GPU state only; do not propose shard leases.\n'
+      ;;
+    dynamic_backfill)
+      printf '  - Use dataevolver.runtime.gpu_scheduler for each scheduling cycle.\n'
+      printf '  - Reserve explicitly reserved GPUs and busy/high-utilization GPUs before leasing new shards.\n'
+      printf '  - Fill idle GPUs with independent Blender render, scene-view gate, rotation8, SR/contact-sheet, VLM request, or audit shards.\n'
+      printf '  - Keep fragile HYWorld pano/worldgen on the smallest stable GPU set; do not fan out same-resolution OOM retries.\n'
+      ;;
+    fixed_range)
+      printf '  - Restrict future leases to include_gpus after subtracting reserve_gpus.\n'
+      printf '  - Treat GPUs outside the fixed range as unavailable even if nvidia-smi shows them idle.\n'
+      ;;
+  esac
+  if [[ "$PAPER_VALIDATION" == "1" ]]; then
+    printf '  - Paper validation requires timing_ledger.json, gpu_shards.json, RUN_STATE.json, quality reports, and failure evidence.\n'
+    printf '  - Quality gates and intermediate review outrank raw GPU occupancy.\n'
+  fi
 }
 
 print_env_plan() {
@@ -297,6 +363,10 @@ print_config_plan() {
   printf '\nNon-sensitive variables to export later:\n'
   printf '  DATAEVOLVER_MODEL_ROOT=%s\n' "$MODEL_ROOT"
   printf '  DATAEVOLVER_WORKSPACE_ROOT=%s\n' "$WORKSPACE_ROOT"
+  printf '  DATAEVOLVER_GPU_POLICY=%s\n' "$GPU_POLICY"
+  printf '  DATAEVOLVER_INCLUDE_GPUS=%s\n' "$INCLUDE_GPUS"
+  printf '  DATAEVOLVER_RESERVE_GPUS=%s\n' "${RESERVE_GPUS:-}"
+  printf '  DATAEVOLVER_PAPER_VALIDATION=%s\n' "$PAPER_VALIDATION"
   printf '  BLENDER_BIN=/path/to/blender\n'
   if [[ "$PROFILE" == "default" || "$PROFILE" == "full" || "$PROFILE" == "world_model" ]]; then
     printf '  QWEN_IMAGE_MODEL_PATH=%s/Qwen-Image-2512\n' "$MODEL_ROOT"
@@ -348,7 +418,7 @@ write_local_config() {
     die "--write-local-config requires python3 or python for safe JSON writing"
   fi
 
-  MODEL_MANIFEST="$(model_manifest)" "$python_bin" - "$PROFILE" "$WORKSPACE_ROOT" "$MODEL_ROOT" "$PYTHON_BACKEND" "$out_dir" <<'PY'
+  MODEL_MANIFEST="$(model_manifest)" "$python_bin" - "$PROFILE" "$WORKSPACE_ROOT" "$MODEL_ROOT" "$PYTHON_BACKEND" "$out_dir" "$GPU_POLICY" "$INCLUDE_GPUS" "$RESERVE_GPUS" "$PAPER_VALIDATION" <<'PY'
 import json
 import os
 import shutil
@@ -357,7 +427,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-profile, workspace_root, model_root, python_backend, out_dir = sys.argv[1:6]
+profile, workspace_root, model_root, python_backend, out_dir, gpu_policy, include_gpus, reserve_gpus, paper_validation_text = sys.argv[1:10]
+paper_validation = paper_validation_text == "1"
 out = Path(out_dir)
 out.mkdir(parents=True, exist_ok=True)
 
@@ -481,6 +552,14 @@ if tooling_status["nvidia-smi"]["status"] == "missing":
     next_actions.append("Confirm GPU/CUDA on the target host before real model setup.")
 if access_requirements:
     next_actions.append("Confirm Hugging Face access for gated/access-dependent model repos.")
+if gpu_policy == "inspect_only":
+    next_actions.append("Inspect GPU inventory and service occupancy before choosing a real shard policy.")
+elif gpu_policy == "dynamic_backfill":
+    next_actions.append("Before real GPU work, run a fresh nvidia-smi probe and use dataevolver.runtime.gpu_scheduler for each dynamic backfill cycle.")
+elif gpu_policy == "fixed_range":
+    next_actions.append("Before real GPU work, confirm include_gpus and reserve_gpus still match the target host state.")
+if paper_validation:
+    next_actions.append("For paper validation, initialize timing_ledger.json, gpu_shards.json, RUN_STATE.json, quality reports, and failure evidence before the first real shard.")
 next_actions.append("Before real setup, source reviewed path overrides derived from env.sh.example.")
 next_actions.append("Run the generated production profile through `python -m dataevolver.cli.production doctor` before starting workers.")
 next_actions.append("Run smoke tests in order: preflight, import smoke, Stage 2, Stage 2.5, Stage 3 shape-only, Stage 3 textured, Stage 5.5 VLM loader.")
@@ -492,6 +571,42 @@ target_workflow = {
     "world_model": "world_model_scene",
     "custom": "custom_model_planning",
 }[profile]
+
+gpu_plan = {
+    "mode": "dry_run_only",
+    "policy": gpu_policy,
+    "include_gpus": include_gpus,
+    "reserve_gpus": reserve_gpus,
+    "scheduler": "dataevolver.runtime.gpu_scheduler",
+    "preflight_commands": [
+        "nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu,uuid --format=csv",
+        "nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv || true",
+        "ps -eo pid,comm,args | grep -Ei 'vllm|hyworld|blender|python' | head -n 80",
+    ],
+    "rules": [
+        "Do not launch GPU jobs from onboarding.",
+        "Reserve explicitly reserved GPUs and busy/high-utilization GPUs before leasing new shards.",
+        "Use independent render, scene-view, rotation8, SR/contact-sheet, VLM request, and audit shards as backfill work.",
+        "Keep fragile HYWorld pano/worldgen on the smallest stable GPU set before scaling.",
+    ],
+}
+
+server_preflight = {
+    "mode": "dry_run_local_probe",
+    "tooling_status": tooling_status,
+    "gpu_probe_required_on_target_host": True,
+    "disk_probe_required_on_target_host": True,
+    "commands_not_executed_by_onboarding": gpu_plan["preflight_commands"],
+}
+
+ledger_requirements = {
+    "timing_ledger": paper_validation,
+    "gpu_shards": paper_validation or gpu_policy in {"dynamic_backfill", "fixed_range"},
+    "run_state": paper_validation,
+    "quality_report": paper_validation,
+    "failure_cases": paper_validation,
+    "gpu_hours_formula": "elapsed_seconds * gpu_count / 3600",
+}
 
 payload = {
     "profile": profile,
@@ -506,9 +621,17 @@ payload = {
         "allow_real_install": False,
         "allow_real_model_download": False,
     },
+    "execution_mode": {
+        "mode": "dry_run_only",
+        "allow_gpu_jobs": False,
+        "allow_service_kill": False,
+        "allow_long_running_jobs": False,
+    },
+    "paper_validation": paper_validation,
     "model_root": model_root,
     "workspace_root": workspace_root,
     "tooling_status": tooling_status,
+    "server_preflight": server_preflight,
     "models": models,
     "custom_models": [] if profile != "custom" else [{
         "role": "unspecified",
@@ -517,6 +640,11 @@ payload = {
         "notes": "Fill from onboarding interview before real deployment.",
     }],
     "access_requirements": access_requirements,
+    "gpu_policy": gpu_policy,
+    "include_gpus": include_gpus,
+    "reserve_gpus": reserve_gpus,
+    "gpu_plan": gpu_plan,
+    "ledger_requirements": ledger_requirements,
     "path_override_plan": path_override_plan,
     "v1_blockers": [
         "Source or export the path override variables before running the pipeline on a new host.",
@@ -571,6 +699,13 @@ production_profile = {
         {"name": "stage2-qwen-image", "kind": "stage2", "python": "dataevolver_python", "device": "cuda:0", "model_path": str(Path(model_root) / "Qwen-Image-2512")},
         {"name": "stage3-hunyuan", "kind": "stage3", "python": "dataevolver_python", "device": "cuda:1"},
     ],
+    "gpu_policy": {
+        "policy": gpu_policy,
+        "include_gpus": include_gpus,
+        "reserve_gpus": reserve_gpus,
+        "scheduler": "dataevolver.runtime.gpu_scheduler",
+    },
+    "paper_validation": paper_validation,
     "health_endpoints": [],
 }
 if profile == "world_model":
@@ -632,6 +767,17 @@ override_rows = "\n".join(
 )
 
 next_action_rows = "\n".join(f"- {item}" for item in next_actions)
+
+gpu_policy_rows = f"""- GPU policy: `{gpu_policy}`
+- Included GPUs: `{include_gpus}`
+- Reserved GPUs: `{reserve_gpus or 'none'}`
+- Scheduler: `dataevolver.runtime.gpu_scheduler`
+- Execution boundary: dry-run only; no GPU jobs, service restarts, or long-running jobs were launched."""
+
+ledger_rows = "\n".join(
+    f"- {key}: {value}"
+    for key, value in ledger_requirements.items()
+)
 
 dependency_plan = """Use `uv venv .venv --python 3.10 --system-site-packages` first on shared GPU servers so a validated system NVIDIA PyTorch build can be reused. Install the CUDA wheel only when `import torch` fails inside the venv or reports no usable CUDA.
 
@@ -700,6 +846,7 @@ Generated by `src/dataevolver/cli/bootstrap_dataevolver_default.sh` in dry-run m
 - Workspace root: `{workspace_root}`
 - Model root: `{model_root}`
 - Python backend preference: `{python_backend}`
+- Paper validation: `{paper_validation}`
 - Install policy: dry-run only; no real install or model download has been performed.
 
 ## Models
@@ -709,6 +856,14 @@ Generated by `src/dataevolver/cli/bootstrap_dataevolver_default.sh` in dry-run m
 ## Preflight Gaps
 
 {missing_tool_rows}
+
+## GPU Policy
+
+{gpu_policy_rows}
+
+## Ledger Requirements
+
+{ledger_rows}
 
 ## Hugging Face Access
 
@@ -754,6 +909,10 @@ env_lines = [
     f"export BLENDER_BIN={shlex.quote(shutil.which('blender') or '/path/to/blender')}",
     f"export DATAEVOLVER_PYTHON={shlex.quote(str(Path(workspace_root) / '.venv/bin/python'))}",
     f"export DATAEVOLVER_PRODUCTION_PROFILE={shlex.quote(str(Path(workspace_root) / '.dataevolver/local/production_profile.json'))}",
+    f"export DATAEVOLVER_GPU_POLICY={shlex.quote(gpu_policy)}",
+    f"export DATAEVOLVER_INCLUDE_GPUS={shlex.quote(include_gpus)}",
+    f"export DATAEVOLVER_RESERVE_GPUS={shlex.quote(reserve_gpus)}",
+    f"export DATAEVOLVER_PAPER_VALIDATION={shlex.quote('1' if paper_validation else '0')}",
 ]
 for model in models:
     env_name = model.get("env")
@@ -795,6 +954,7 @@ PY
 }
 
 print_probe_plan
+print_gpu_plan
 print_env_plan
 print_model_plan
 print_config_plan


### PR DESCRIPTION
## Summary
- expand `dataevolver-onboarding` into the standard dry-run entrypoint for server, uv, model-path, GPU-policy, and HYWorld/paper-validation setup
- add generic GPU policy handling to the bootstrap dry-run without committing host-specific GPU ranges or service-card reservations
- document inspect-first onboarding in README/README_zh and keep user GPU choices in ignored `.dataevolver/local/` profiles

## Validation
- skill validation for `.agents/skills/dataevolver-onboarding`
- `PYTHONPATH=src python3 -m unittest dataevolver.testing.test_gpu_scheduler -v`
- `python3 -m py_compile src/dataevolver/runtime/gpu_scheduler.py src/dataevolver/testing/test_gpu_scheduler.py`
- `bash -n src/dataevolver/cli/bootstrap_dataevolver_default.sh`
- `git diff --check`
- bootstrap dry-run smoke for default `inspect_only` world-model profile using disposable local paths
- bootstrap dry-run smoke for explicit `dynamic_backfill` + `paper_validation` using disposable local paths
- strict scan found no concrete local GPU ranges, host names, lab paths, or real token/private-key patterns

## Notes
- `graphify update .` still fails locally with `permission denied: graphify`, matching the existing environment issue.