### PR TITLE
[codex] add student authors and affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 </p>
 
 <p align="center">
+  <strong>Qisong Zhang, Wenzhuo Wu, Zhuangzhuang Jia, Yunhao Yang, Shuo Zhang</strong><br/>
+  School of Artificial Intelligence, Beijing University of Posts and Telecommunications (BUPT)
+</p>
+
+<p align="center">
   <a href="https://arxiv.org/abs/2605.01789"><img src="https://img.shields.io/badge/Paper-arXiv-b31b1b?logo=arxiv&logoColor=white" alt="Paper: arXiv"/></a>
   <a href="https://pris-cv.github.io/DataEvolver/"><img src="https://img.shields.io/badge/Website-Project%20Page-1f6feb?logo=githubpages&logoColor=white" alt="Project website"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-green" alt="License: Apache-2.0"/></a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,6 +10,11 @@
 </p>
 
 <p align="center">
+  <strong>Qisong Zhang, Wenzhuo Wu, Zhuangzhuang Jia, Yunhao Yang, Shuo Zhang</strong><br/>
+  北京邮电大学人工智能学院
+</p>
+
+<p align="center">
   <a href="https://arxiv.org/abs/2605.01789"><img src="https://img.shields.io/badge/Paper-arXiv-b31b1b?logo=arxiv&logoColor=white" alt="Paper: arXiv"/></a>
   <a href="https://pris-cv.github.io/DataEvolver/"><img src="https://img.shields.io/badge/Website-Project%20Page-1f6feb?logo=githubpages&logoColor=white" alt="Project website"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-green" alt="License: Apache-2.0"/></a>

--- a/web/index.html
+++ b/web/index.html
@@ -218,7 +218,28 @@ em{font-style:italic;color:var(--body-strong)}
 }
 .hero-subtitle{
   font-size:1.0625rem;line-height:1.6;max-width:560px;
-  color:var(--body);margin-bottom:32px;
+  color:var(--body);margin-bottom:18px;
+}
+.hero-authors{
+  max-width:560px;
+  background:rgba(239,233,222,0.72);
+  border:1px solid var(--hairline);
+  border-radius:var(--radius-lg);
+  padding:14px 16px;
+  margin-bottom:18px;
+}
+.hero-authors strong{
+  display:block;
+  color:var(--body-strong);
+  font-size:0.9rem;
+  line-height:1.45;
+}
+.hero-affiliation{
+  display:block;
+  color:var(--muted);
+  font-size:0.82rem;
+  line-height:1.45;
+  margin-top:4px;
 }
 .hero-actions{display:flex;gap:12px;flex-wrap:wrap}
 .hero-awards{
@@ -1419,6 +1440,10 @@ em{font-style:italic;color:var(--body-strong)}
       <p class="hero-subtitle">
         DataEvolver is an autonomous dataset construction framework where <em>goal-driven loop agents</em> choose and compose text-to-image, image editing, text-to-video, and image-to-3D interfaces, then use VLM feedback and WebSearch research priors to turn user requests or papers into reproducible data pipelines.
       </p>
+      <div class="hero-authors" aria-label="Authors and affiliation">
+        <strong>Qisong Zhang, Wenzhuo Wu, Zhuangzhuang Jia, Yunhao Yang, Shuo Zhang</strong>
+        <span class="hero-affiliation">School of Artificial Intelligence, Beijing University of Posts and Telecommunications (BUPT)</span>
+      </div>
       <div class="hero-awards" aria-label="Project highlights">
         <span class="hero-award">📄 arXiv 2605.01789</span>
         <span class="hero-award">🏆 KDD Workshop Oral</span>

--- a/web/index_zh.html
+++ b/web/index_zh.html
@@ -218,7 +218,28 @@ em{font-style:italic;color:var(--body-strong)}
 }
 .hero-subtitle{
   font-size:1.0625rem;line-height:1.6;max-width:560px;
-  color:var(--body);margin-bottom:32px;
+  color:var(--body);margin-bottom:18px;
+}
+.hero-authors{
+  max-width:560px;
+  background:rgba(239,233,222,0.72);
+  border:1px solid var(--hairline);
+  border-radius:var(--radius-lg);
+  padding:14px 16px;
+  margin-bottom:18px;
+}
+.hero-authors strong{
+  display:block;
+  color:var(--body-strong);
+  font-size:0.9rem;
+  line-height:1.45;
+}
+.hero-affiliation{
+  display:block;
+  color:var(--muted);
+  font-size:0.82rem;
+  line-height:1.45;
+  margin-top:4px;
 }
 .hero-actions{display:flex;gap:12px;flex-wrap:wrap}
 .hero-awards{
@@ -1419,6 +1440,10 @@ em{font-style:italic;color:var(--body-strong)}
       <p class="hero-subtitle">
         DataEvolver 是一个自动化数据集构建框架，其中 <em>目标驱动的 loop agents</em> 会选择并组合 text-to-image、image editing、text-to-video 与 image-to-3D 接口，再利用 VLM 反馈和 WebSearch 研究先验，将用户需求或论文转化为可复现的数据 pipeline。
       </p>
+      <div class="hero-authors" aria-label="作者和单位">
+        <strong>Qisong Zhang, Wenzhuo Wu, Zhuangzhuang Jia, Yunhao Yang, Shuo Zhang</strong>
+        <span class="hero-affiliation">北京邮电大学人工智能学院</span>
+      </div>
       <div class="hero-awards" aria-label="Project highlights">
         <span class="hero-award">📄 arXiv 2605.01789</span>
         <span class="hero-award">🏆 KDD Workshop Oral</span>


### PR DESCRIPTION
## Summary

This PR adds the public student author and BUPT affiliation line to the bilingual README files and the bilingual GitHub Pages hero section.

The author list is intentionally limited to the first-line student authors from the KDD LaTeX source: Qisong Zhang, Wenzhuo Wu, Zhuangzhuang Jia, Yunhao Yang, and Shuo Zhang. TeleAI and advisor information are not added to the new top README / website hero metadata blocks.

## Changes

- Add the five student authors and BUPT affiliation above the badge row in `README.md`.
- Add the same author line and Chinese BUPT affiliation above the badge row in `README_zh.md`.
- Add a warm-card author/affiliation block to the English website hero.
- Add the corresponding author/affiliation block to the Simplified Chinese website hero.

## Validation

- `git diff --check`
- Static local-reference check for `web/index.html` and `web/index_zh.html`: no missing local assets.
- Local website smoke with Python `http.server` and Playwright:
  - English desktop hero screenshot inspected.
  - Simplified Chinese mobile hero screenshot inspected.
  - Mobile width check showed no horizontal overflow.

Note: the local Python static server produced an intermittent `ERR_EMPTY_RESPONSE` for the existing MP4 media request during Playwright smoke. Image and page assets loaded successfully, and the warning is unrelated to this author/affiliation text change.
